### PR TITLE
kano-screen-settings: Adding the -r option

### DIFF
--- a/kano-screen-settings
+++ b/kano-screen-settings
@@ -121,12 +121,15 @@ screen, use the -o option again, but this time to enable overscan.
                         help="display the HDMI modes that are" + \
                              "supported by your screen")
 
+    parser.add_argument("-r", "--reset", action="store_true",
+                        help="reset the mode settings to the original state")
+
     parser.add_argument("-s", "--set-mode", metavar="group:number",
                         help="set HDMI mode")
 
     args = parser.parse_args()
     if args.list_modes == False and args.set_mode == None and \
-       args.overscan == None:
+       args.overscan == None and args.reset == False:
         parser.print_help()
         sys.exit(0)
 
@@ -134,6 +137,12 @@ screen, use the -o option again, but this time to enable overscan.
 
 def main():
     args = parse_args()
+
+    if args.reset:
+        set_config_option("disable_overscan", 1)
+        set_config_option("hdmi_group", None)
+        set_config_option("hdmi_mode", None)
+        return 0
 
     if args.list_modes:
         print_supported_modes()


### PR DESCRIPTION
This new option allows you to reset your screen settings back to the original state.

Fixes https://github.com/KanoComputing/peldins/issues/590

cc @alex5imon 
