### PR TITLE
Installing udhcpc post connection script

### DIFF
--- a/debian/kano-toolset.install
+++ b/debian/kano-toolset.install
@@ -6,3 +6,5 @@ js/backend-api.js /usr/share/kano-toolset
 uinput/uinput /usr/bin
 uinput/pyinputevent.py /usr/lib/python2.7/dist-packages
 uinput/scancodes.py /usr/lib/python2.7/dist-packages
+
+udhcpc/kano.script /etc/udhcpc

--- a/udhcpc/kano.script
+++ b/udhcpc/kano.script
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Busybox udhcpc dispatcher script. Copyright (C) 2009 by Axel Beckert.
+#
+# Based on the busybox example scripts and the old udhcp source
+# package default.* scripts.
+
+RESOLV_CONF="/etc/resolv.conf"
+
+case $1 in
+    bound|renew)
+	[ -n "$broadcast" ] && BROADCAST="broadcast $broadcast"
+	[ -n "$subnet" ] && NETMASK="netmask $subnet"
+
+	/sbin/ifconfig $interface $ip $BROADCAST $NETMASK
+
+	if [ -n "$router" ]; then
+	    echo "$0: Resetting default routes"
+	    while /sbin/route del default gw 0.0.0.0 dev $interface; do :; done
+
+	    metric=0
+	    for i in $router; do
+		/sbin/route add default gw $i dev $interface metric $metric
+		metric=$(($metric + 1))
+	    done
+	fi
+
+	# Update resolver configuration file
+	R=""
+	[ -n "$domain" ] && R="domain $domain
+"
+	for i in $dns; do
+	    echo "$0: Adding DNS $i"
+	    R="${R}nameserver $i
+"
+	done
+
+	if [ -x /sbin/resolvconf ]; then
+	    echo -n "$R" | resolvconf -a "${interface}.udhcpc"
+	else
+	    echo -n "$R" > "$RESOLV_CONF"
+	fi
+     
+	# set local timezone and network time upon interface up
+        # save the result of this work in small log files under /var/log
+	tzupdated=`/usr/local/bin/tzupdate 2>&1`
+	if [ "$?" -eq 0 ]; then
+	  echo "SUCCESS: $tzupdated" > /var/log/tzupdate.log
+	else
+	  echo "FAIL: $tzupdated" > /var/log/tzupdate.log
+	fi
+	echo $tzupdated | logger -t tzupdate -i
+
+	# set time from a network NTP server
+	dated=`/usr/bin/rdate -ncv $(cat /etc/timeserver.conf) 2>&1`
+	if [ "$?" -eq 0 ]; then
+	  echo "SUCCESS: $dated" > /var/log/rdate.log
+	else
+	  echo "FAIL: $dated" > /var/log/rdate.log
+	fi
+	echo $dated | logger -t rdate -i
+
+	;;
+
+    deconfig)
+	if [ -x /sbin/resolvconf ]; then
+	    resolvconf -d "${interface}.udhcpc"
+	fi
+	/sbin/ifconfig $interface 0.0.0.0
+	;;
+
+    leasefail)
+	echo "$0: Lease failed: $message"
+	;;
+
+    nak)
+	echo "$0: Received a NAK: $message"
+	;;
+
+    *)
+	echo "$0: Unknown udhcpc command: $1";
+	exit 1;
+	;;
+esac


### PR DESCRIPTION
 o udhcpc script is currently installed as part of spindle,
   users upgrading from previous kanux version will notice
   their wifi autoconnect feature fails. This should fix it.
o I am not 100% this will work correctly on subsequent upgrades
 (i.e. when this udhcpc script is already installed)
