### PR TITLE
Webapp now provides a pipe via which we can send Javascript code

### DIFF
--- a/kano/webapp.py
+++ b/kano/webapp.py
@@ -17,7 +17,6 @@ import warnings
 import subprocess
 
 import thread
-import time
 import atexit
 
 from kano.window import gdk_window_settings


### PR DESCRIPTION
- On initial load, a thread creates a file system FIFO
- External processes can send Javascript code, it is sent to Webkit browser
- On termination the pipe is removed so scripts know if Webkit is/not running
- Tested on Pong and Minecraft
