### PR TITLE
UDHCPC was only started for WPA connections

### DIFF
--- a/kano/network.py
+++ b/kano/network.py
@@ -447,6 +447,7 @@ def connect(iface, essid, encrypt='off', seckey=None, wpa_custom_file=None):
     elif encrypt == 'wpa':
         logger.info("Starting wpa_supplicant for network '%s' to interface %s" % (essid, iface))
         wpafile = '/etc/kano_wpa_connect.conf'
+        associated = False
         wpa_conf(essid, seckey, confile=wpafile)
 
         try:


### PR DESCRIPTION
- udhcpc execution was only in the scope for wpa connections
- timeout delay for network association was not compared properly,
  thus the fix increases from 15 to 20 secs.
