### PR TITLE
wireless improvement to detect if associated and authenticated

### DIFF
--- a/kano/network.py
+++ b/kano/network.py
@@ -310,7 +310,7 @@ def is_connected(iface):
     # ifplugstatus will tell us if we are associated
     # and authenticated to the AP with return code 2
     _, _, rc = run_cmd ("/usr/sbin/ifplugstatus %s" % iface)
-    linked = rc == 2
+    linked = (rc == 2)
 
     return (essid, mode, ap, linked)
 


### PR DESCRIPTION
- We are now using ifplugstatus to effectively determine
  if we are both associated and linked to the AP
  (when the passphrase was wrong it was still understood as associated)
- Improved a minor safe control for if wpa_cli status returns no data
