### PR TITLE
Added type check for items in given list

### DIFF
--- a/kano/gtk3/kano_combobox.py
+++ b/kano/gtk3/kano_combobox.py
@@ -201,9 +201,14 @@ class KanoComboBox(Gtk.Button):
 
     def set_items(self, items):
         # use this to set a list of string items for the dropdown menu
-        # it makes sure the parameter is actually a list
+        # it makes sure the parameter is actually a List which contains Strings
         if not isinstance(items, types.ListType):
             raise TypeError("KanoComboBox: set_items(): You must supply a List when setting items")
+
+        for item in items:
+            if not isinstance(item, types.StringTypes):
+                raise TypeError("KanoComboBox: append(): You must supply a String when appending text")
+
         self.items = list(items)
         self.update_dropdown()
 


### PR DESCRIPTION
_KanoComboBox - Custom ComboBox widget_
- ability to set the number of items to display in dropdown
- can set a default text instead of a blank box e.g. _"Select continent"_
- useful methods to `get` or `set` the _index_ or _text_ of selected item
- custom signals: dropdown `popup`, dropdown item `selected`, dropdown selected item `changed`
- has type checks for supplied list of items and items

https://github.com/KanoComputing/kano-settings/issues/39
