### PR TITLE
Change strategy to find Rpi model B+

### DIFF
--- a/kano/utils.py
+++ b/kano/utils.py
@@ -382,6 +382,9 @@ def get_volume():
 
 
 def is_model_b_plus():
+    #
+    # TODO: Find a better strategy so we do not depend on a fixed hexadecimal release number
+    #
     try:
         o, _, _ = run_cmd('cat /proc/cpuinfo')
         o = o.splitlines()


### PR DESCRIPTION
- Removed list of usb devices, this was failing because the USB hubs
  are the same on both models.
- Comparing cpuinfo details to find the Release version starts at 0x10 on model B+
