### PR TITLE
Switch to resolvconf for DNS config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (1.3-6) unstable; urgency=low
+
+  * resolvconf now used for handling DNS
+
+ -- Team Kano <dev@kano.me>  Wed, 21 Jan 2014 14:40:00 +0000
+
 kano-toolset (1.3-5) unstable; urgency=low
 
   * logging.sh now supports sh too

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,8 @@ Build-Depends: debhelper (>= 9)
 Package: kano-toolset
 Architecture: all
 Depends: ${misc:Depends}, python-gtk2, python-webkit,
-         fping, python, zenity, bc, ifplugd, python-yaml, python-pyinotify
+         fping, python, zenity, bc, ifplugd, python-yaml, python-pyinotify,
+         resolvconf
 Replaces: kano-init (<< 1.0-46)
 Breaks: kano-init (<< 1.0-46)
 Description: Collection of tools for Kanux

--- a/kano/network.py
+++ b/kano/network.py
@@ -19,10 +19,13 @@ import subprocess
 import shlex
 import json
 import re
+import shutil
 from kano.utils import run_cmd, get_user_unsudoed, run_bg, write_file_contents
 from kano.logging import logger
 
-DNS_FILE = '/etc/resolv.conf'
+DNS_FILE = '/etc/resolvconf/resolv.conf.d/base'
+DNS_INTERFACES_FILE = '/etc/resolvconf/interface-order'
+DNS_INTERFACES_BACKUP_FILE = '/etc/resolvconf/interface-order.backup'
 
 
 class IWList():
@@ -647,3 +650,23 @@ def set_dns(servers):
         ['nameserver {}'.format(server) for server in servers])
 
     write_file_contents(DNS_FILE, server_str)
+
+
+def clear_dns_interfaces():
+    if os.path.exists(DNS_INTERFACES_BACKUP_FILE):
+        # Already cleared
+        return
+
+    shutil.move(DNS_INTERFACES_FILE, DNS_INTERFACES_BACKUP_FILE)
+
+    with open(DNS_INTERFACES_FILE, 'w') as f:
+        f.close()
+
+
+def restore_dns_interfaces():
+    if os.path.exists(DNS_INTERFACES_BACKUP_FILE):
+        shutil.move(DNS_INTERFACES_BACKUP_FILE, DNS_INTERFACES_FILE)
+
+
+def refresh_resolvconf():
+    run_bg('resolvconf -u')


### PR DESCRIPTION
KanoComputing/peldins#1543
When directly editing `/etc/resolv.conf`, changes can be lost if the
interface reacquires addresses via DHCP. This can cause custom DNS
settings to be lost. Resolvconf allows finer configuration DNS
configuration.

Resolvconf dynamically creates the `/etc/resolv.conf` file by
concatenating the following:

1 - `/etc/resolvconf/resolv.conf.d/head`
2 - Any DNS set on interfaces (the order of which are determined by the
    contents of `/ect/resolvconf/interface-order` and limited to 3 DNS
    servers)
3 - `/etc/resolvconf/resolv.conf.d/base`
4 - `/etc/resolvconf/resolv.conf.d/tail`

`/etc/resolv.conf` can be updated by running `resolvconf -u`

This patch forces the use of resolvconf to replace direct
`/etc/resolv.conf` editing and provides ability to exclude DNS servers
configured on interfaces when determining the `/etc/resolv.conf` file.

Also bumps the version to 1.3-6 to allow for dependency on this
functionality.
