### PR TITLE
Migrating to the new tracker

### DIFF
--- a/bin/kano-shutdown
+++ b/bin/kano-shutdown
@@ -9,7 +9,7 @@
 #
 
 # Report shutdown event to Kano Tracker
-kano-profile-cli increment_app_runtime shutdown 0
+kano-tracker-ctl +1 shutdown
 
 kano-sync --backup -s &
 lxsession-logout -p "Logout from this session?" -b /usr/share/kano-desktop/images/kano-logout-face.png -s top


### PR DESCRIPTION
Increment the `shutdown` counter.

This package unfortunately can't have a dependency on kano-profile as profile depends on the toolset. Ideally, we should move the `kano-shutdown` script to kano-desktop in the future.

Related to:
https://github.com/KanoComputing/peldins/issues/1358
https://github.com/KanoComputing/kano-profile/pull/201

cc @alex5imon 
