### PR TITLE
Remove unnecessary import

### DIFF
--- a/kano/webapp.py
+++ b/kano/webapp.py
@@ -14,7 +14,6 @@ import re
 import os
 import urllib
 import warnings
-import subprocess
 
 import thread
 import atexit


### PR DESCRIPTION
After the removal of calls to zenity the subprocess module is no longer necessary.

Related to https://github.com/KanoComputing/peldins/issues/1629
