### PR TITLE
In kano-launcher, don't kill the vnc server if it is running.

### DIFF
--- a/kano-launcher-no-kill-list
+++ b/kano-launcher-no-kill-list
@@ -10,3 +10,4 @@ menu-cached
 python /usr/bin/kano-feedback-widget
 python /usr/bin/kano-tracker-ctl
 /usr/bin/xbindkeys
+x11vnc


### PR DESCRIPTION
This PR just adds x11vnc to the list of things not to kill. I have checked that it doesn't kill vnc and that it still kills remaining apps  (note that if a blank line is left at the end of the no-kill-list, this matches everything and thus
nothing gets killed). I have also checked that everything which is running before apps are launched remains running after an app is launched and shut down. However if there are any further daemon-like apps, like vnc, which should remain running, please let me know.
