### PR TITLE
Don't kill lxterminal as this may annoy techy parents (or kids).

### DIFF
--- a/kano-launcher-no-kill-list
+++ b/kano-launcher-no-kill-list
@@ -11,3 +11,4 @@ python /usr/bin/kano-feedback-widget
 python /usr/bin/kano-tracker-ctl
 /usr/bin/xbindkeys
 x11vnc
+lxterminal


### PR DESCRIPTION
Because kano-launcher now uses a whitelist rather than a blacklist when killling processes, it kills the terminal which may annoy parents who use it. Therefore this PR adds it to the whitelist. 
