### PR TITLE
Fix for message "You are connected to network"

### DIFF
--- a/kano/network.py
+++ b/kano/network.py
@@ -332,8 +332,7 @@ def is_connected(iface):
 
     # Association status can be queried via ifplugstatus,
     # but we are returning linked=True if Internet is actually up.
-    _, _, rc = run_cmd("/usr/bin/is_internet")
-    linked = (rc == 0)
+    linked = is_internet()
 
     return (essid, mode, ap, linked)
 


### PR DESCRIPTION
- The message would be displayed after a wrong password,
  which would not be true that you are connecte.
- With this fix it is displayed only if both association is ok and Internet is up.
