### PR TITLE
Enable UTF8 for kano.logging

### DIFF
--- a/bin/kano-logs
+++ b/bin/kano-logs
@@ -88,7 +88,7 @@ def show_logs(app=None, linearised=False):
             output += format_log_data(get_log_data(log)) + "\n"
 
     if len(output) > 0:
-        pydoc.pipepager(output, cmd='less -R')
+        pydoc.pipepager(output.encode('utf-8'), cmd='less -R')
 
 
 def format_log_data(data, default_app_name=""):
@@ -101,7 +101,7 @@ def format_log_data(data, default_app_name=""):
 
         dt = datetime.datetime.fromtimestamp(entry["time"])
         time = dt.strftime('%Y-%m-%d %H:%M:%S')
-        output += "{} {}[{}] {} {}\n".format(
+        output += u"{} {}[{}] {} {}\n".format(
             decorate_string_only_terminal(time, "cyan"),
             app_name,
             decorate_string_only_terminal(entry["pid"], "yellow"),
@@ -123,15 +123,15 @@ class EventHandler(pyinotify.ProcessEvent):
             all_data += data[-10:]
 
         all_data.sort(lambda a, b: cmp(a["time"], b["time"]))
-        print format_log_data(all_data),
+        print format_log_data(all_data).encode('utf-8'),
 
     def process_IN_CREATE(self, event):
         new = self._process_file(event.pathname)
-        print format_log_data(new),
+        print format_log_data(new).encode('utf-8'),
 
     def process_IN_MODIFY(self, event):
         new = self._process_file(event.pathname)
-        print format_log_data(new),
+        print format_log_data(new).encode('utf-8'),
 
     def _process_file(self, path):
         app_name = re.sub(r"\.log$", "", os.path.basename(path))

--- a/kano/logging.py
+++ b/kano/logging.py
@@ -171,7 +171,7 @@ class Logger:
             try:
                 lines = msg.strip().split('\n')
             except AttributeError:
-                # msg.strip() failes if it isn't an ascii or unicode string
+                # msg.strip() fails if it isn't an ascii or unicode string
                 lines = str(msg).split('\n')
 
             log = {}

--- a/kano/logging.py
+++ b/kano/logging.py
@@ -168,7 +168,11 @@ class Logger:
             if self._app_name is None:
                 self.set_app_name(sys.argv[0])
 
-            lines = str(msg).strip().split("\n")
+            try:
+                lines = msg.strip().split('\n')
+            except AttributeError:
+                # msg.strip() failes if it isn't an ascii or unicode string
+                lines = str(msg).split('\n')
 
             log = {}
             log["pid"] = self._pid
@@ -188,13 +192,13 @@ class Logger:
                         self.sync()
 
                 if level <= sys_output_level:
-                    output_line = "{}[{}] {} {}\n".format(
+                    output_line = u"{}[{}] {} {}\n".format(
                         self._app_name,
                         decorate_string_only_terminal(self._pid, "yellow"),
                         decorate_with_preset(log["level"], log["level"], True),
                         log["message"]
                     )
-                    sys.stderr.write(output_line)
+                    sys.stderr.write(output_line.encode('utf-8'))
 
     def sync(self):
         self._log_file.flush()


### PR DESCRIPTION
At the moment, kano.logging cannot handle unicode in log messages:

    from kano.logging import logger
    logger.force_log_level("info")
    logger.info(u"Hell\N{LATIN SMALL LETTER O WITH DIAERESIS} W\N{LATIN SMALL LETTER O WITH DIAERESIS}rld\N{HORIZONTAL ELLIPSIS}")

This patch offers a fix for that.