### PR TITLE
Add functions for minecraft improvments.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (1.3-14) unstable; urgency=low
+
+  * Extra X functions for minecraft.
+
+ -- Team Kano <dev@kano.me>  Tue, 7 Apr 2015 13:51:00 +0100
+
 kano-toolset (1.3-13) unstable; urgency=low
 
   * Added new script kano-tzupdate to use ipinfo.io and custom Kano auth credentials

--- a/kano/webapp.py
+++ b/kano/webapp.py
@@ -11,6 +11,7 @@ Provides a class wrapper on top of a WebKit browser
 '''
 
 import gtk
+from gtk import gdk
 import gobject
 import webkit
 import sys
@@ -77,7 +78,8 @@ class WebApp(object):
     _app_icon = None
     _inspector = False
 
-
+    _disable_minimize = False
+    
     _pipe = True
 
     def run(self):
@@ -133,6 +135,9 @@ class WebApp(object):
                             self._width, self._height, self._decoration,
                             self._maximized, self._centered)
 
+        if self._disable_minimize:
+            win.connect("window-state-event", self._unminimise_if_minimised)
+
         view.open(self._index)
 
         # Start a thread that injects Javascript code coming from a filesystem pipe.
@@ -142,6 +147,12 @@ class WebApp(object):
 
         gtk.main()
 
+    def _unminimise_if_minimised(self, window, event):
+        # Check if we are attempting to minimise the window
+        # if so, try to unminimise it
+        if event.changed_mask & gdk.WINDOW_STATE_ICONIFIED:
+            window.deiconify()
+            
     def _activate_inspector(self, inspector, target_view, splitter):
         inspector_view = webkit.WebView()
         splitter.add2(inspector_view)

--- a/kano/window.py
+++ b/kano/window.py
@@ -14,6 +14,7 @@ from gtk import gdk
 import time
 
 from kano.utils import run_cmd
+import kano.xwindow
 
 BOTTOM_BAR_HEIGHT = 44
 
@@ -134,6 +135,19 @@ def _get_window_by_id(wid):
     return gdk.window_foreign_new(int(wid))
 
 
+def retry_for(fn, secs, *args, **kwargs):
+    '''
+    Retry a function for some time if it returns None
+    '''
+    res = None
+    for i in range(1, secs * 10):
+        res = fn(*args, **kwargs)
+        if res is not None:
+            return res
+        time.sleep(0.1)
+    return res
+
+
 def find_window(title=None, pid=None, wid=None):
     '''
     Finds the gdk window identified by title, pid or wid (X window ID)
@@ -143,19 +157,32 @@ def find_window(title=None, pid=None, wid=None):
     if (title is None) and (pid is None) and (wid is None):
         raise ValueError("At least one identificator needed.")
 
-    win = None
-    for i in range(1, 300):
-        if title is not None:
-            win = _get_window_by_title(title)
-        elif pid is not None:
-            win = _get_window_by_pid(pid)
-        else:
-            win = _get_window_by_id(wid)
-
-        if win is not None:
-            break
-        time.sleep(0.1)
+    win = retry_for(_find_window_any, 30, title=title, pid=pid, wid=wid)
     return win
+
+
+def _find_window_any(title=None, pid=None, wid=None):
+    '''
+    Find the gdk window identified by title, pid or wid (X window ID)
+    '''
+    win = None
+    if title is not None:
+        win = _get_window_by_title(title)
+    elif pid is not None:
+        win = _get_window_by_pid(pid)
+    else:
+        win = _get_window_by_id(wid)
+    return win
+
+
+def get_child_windows(win):
+    ''' Get child windows
+        assumes that there is at least one, so waits for up to
+        30 seconds for it to appear.
+    '''
+    child_xids = retry_for(
+        kano.xwindow.get_child_windows_from_xid, 30, win.xid)
+    return map(_get_window_by_id, child_xids)
 
 
 def gdk_window_settings(win, x=None, y=None, width=None, height=None,

--- a/kano/window.py
+++ b/kano/window.py
@@ -140,11 +140,13 @@ def retry_for(fn, secs, *args, **kwargs):
     Retry a function for some time if it returns None
     '''
     res = None
-    for i in range(1, secs * 10):
+    tries_per_sec = 10
+    sleep_time = 1.0 / tries_per_sec
+    for i in range(1, secs * tries_per_sec):
         res = fn(*args, **kwargs)
         if res is not None:
             return res
-        time.sleep(0.1)
+        time.sleep(sleep_time)
     return res
 
 

--- a/kano/xwindow.py
+++ b/kano/xwindow.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+# xwindow.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: GNU General Public License v2 http://www.gnu.org/licenses/gpl-2.0.txt
+#
+# low level Xlib utilities
+#
+# Be careful mixing calls to this with Gtk.
+
+from contextlib import contextmanager
+import Xlib.display
+from kano.logging import logger
+
+
+def handle_uncaught_errors(err, req):
+    # req is always None in the default error handler
+    logger.error("error from Xlib {}".format(err))
+
+
+@contextmanager
+def display():
+    '''
+     A context manager for  display
+    '''
+    d = Xlib.display.Display()
+    d.set_error_handler(handle_uncaught_errors)
+
+    yield d
+
+    d.close()
+
+
+def find_xwindow_by_id(xid, parent):
+    '''
+    Given a parent Xlib Window, find a window with given xid
+    returning Xlib window object
+    '''
+    try:
+        for c in parent.query_tree().children:
+            if c.id == xid:
+                return c
+            r = find_xwindow_by_id(xid, c)
+            if r is not None:
+                return r
+    except:
+        return None
+
+
+def xid_to_str(xid):
+    ''' make a strign suitable for passing on command line'''
+
+    return hex(xid).rstrip('L')
+
+# NB this function opens its own X connection. This is only safe because
+# we don't return any objects, only xids. Normally Xlib objects must be used
+# in the context of a Display().
+
+def get_child_windows_from_xid(xid):
+    '''
+    Given an X window id, return the xid's of its children
+    '''
+    try:
+        with display() as d:
+            root = d.screen().root
+            xw = find_xwindow_by_id(xid, root)
+            children = []
+            for c in xw.query_tree().children:
+                children.append(xid_to_str(c.id))
+            return children
+    except:
+        return []


### PR DESCRIPTION
This PR adds functions for use in minecraft: 

* kano.windows.get_child_windows: for finding the MPi child window so we can resize it 
* kano.xwindow: functions for use by the daemon which catches tabs

Because make-minecraft will depend on these changes, the version is also incremented.