### PR TITLE
Add a sequence number to  backend-api.js 

### DIFF
--- a/js/backend-api.js
+++ b/js/backend-api.js
@@ -11,6 +11,7 @@
 
 window.backend = {
     callbacks: [],
+    seq: 0,
 
     call: function() {
         if (arguments.length >= 1) {
@@ -43,7 +44,9 @@ window.backend = {
 
         var args_string = args.join('/');
 
-        window.location.hash = 'api:' + func + '/' + args_string;
+        this.seq++; // add a sequence number to ensure string is different from last one
+
+        window.location.hash = 'api:' + func + '/' + this.seq + '/' + args_string;
     },
 
     trigger_cb: function(cb_name, timestamp, result) {
@@ -57,9 +60,10 @@ window.backend = {
                 callback.timestamp === timestamp) {
                 callback.callback(result);
                 backend.callbacks.splice(i, 1);
-                break;
+                return;
             }
         }
+	console.log("callback not found!");
 
     }
 };

--- a/kano/webapp.py
+++ b/kano/webapp.py
@@ -222,7 +222,7 @@ class WebApp(object):
         sys.exit(0)
 
     def _parse_api_call(self, call_str):
-        call_re = r"#api:(\w+)(\[\d+\])?(/[^/]*)*$"
+        call_re = r"#api:(\w+)(\[\d+\])?(/[^/]*)+$"
         call_match = re.search(call_re, call_str)
 
         name = call_match.group(1)
@@ -238,7 +238,8 @@ class WebApp(object):
         if len(args) > 0:
             if args[-1] == "/":
                 args = args[:-1]
-            call += map(urllib.unquote, args.split("/"))
+            arglist = map(urllib.unquote, args.split("/"))
+            call += arglist[1:]  # remove seq
 
         return call
 


### PR DESCRIPTION
This PR should fix a problem in minecraft whereby tab from blocks mode stops working. It was caused by the fact that the API call is encoded as a hash, and the signal  for the hash only gets triggered when the hash string changes, so if the same function is called with the same arguments it doesn't happen. Adding a sequence number to make sure there is some change.

@tombettany @pazdera 