### PR TITLE
utils: Adding get_free_space

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (2.0-1) unstable; urgency=low
+
+  * Adding the get_free_space() function to utils
+
+ -- Team Kano <dev@kano.me>  Wed, 13 May 2015 17:10:00 +0100
+
 kano-toolset (1.3-14) unstable; urgency=low
 
   * Extra X functions for minecraft.

--- a/kano/utils.py
+++ b/kano/utils.py
@@ -546,3 +546,21 @@ def sed(pattern, replacement, file_path, use_regexp=True):
                 changed += 1
 
     return changed
+
+
+def get_free_space(path="/"):
+    """
+        Returns the amount of free space in certain location in MB
+
+        :param path: The location to measure the free space at.
+        :type path: str
+
+        :return: Number of free megabytes.
+        :rtype: int
+    """
+
+    out, err, rv = run_cmd("df {}".format(path))
+
+    device, size, used, free, percent, mp = out.split('\n')[1].split()
+
+    return int(free) / 1024


### PR DESCRIPTION
A function to check for the amount of free space on disk.

This will be useful in the updater for checking how much space we have before updating.

Related to: https://github.com/KanoComputing/peldins/issues/1798

cc @alex5imon @tombettany 