### PR TITLE
Check whether the log_dir arg is present

### DIFF
--- a/bin/kano-logs
+++ b/bin/kano-logs
@@ -255,7 +255,7 @@ def main():
 
     args = process_args()
 
-    if 'log_dir' in args:
+    if 'log_dir' in args and args['log_dir']:
         force_log_dirs = [args['log_dir']]
 
     if args["which"] == "show":


### PR DESCRIPTION
ArgumentParser seems to be setting the log_dir key to None, which passes this condition but breaks the rest of the code. This should fix the problem.

Reported by: @tombettany 

cc @Ealdwulf 