### PR TITLE
Add unsudo option

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+kano-toolset (2.0-2) unstable; urgency=low
+
+  * Add 'unsudo' option to run_cmd, run_cmd_bg, run_cmd_log
+
+ -- Team Kano <dev@kano.me>  Tue, 15 May 2015 18:59:00 +0100
 kano-toolset (2.0-1) unstable; urgency=low
 
   * Adding the get_free_space() function to utils

--- a/kano/utils.py
+++ b/kano/utils.py
@@ -22,7 +22,7 @@ import grp
 import json
 
 
-def run_cmd(cmd, localised=False):
+def run_cmd(cmd, localised=False, unsudo=False):
     '''
     Executes cmd, returning stdout, stderr, return code
     if localised is False, LC_ALL will be set to "C"
@@ -30,6 +30,9 @@ def run_cmd(cmd, localised=False):
     env = os.environ.copy()
     if not localised:
         env['LC_ALL'] = 'C'
+
+    if unsudo and 'SUDO_USER' in os.environ and os.environ['SUDO_USER'] != 'root':
+        cmd = "sudo -u {} bash -c '{}' ".format(os.environ['SUDO_USER'], cmd)
 
     process = subprocess.Popen(cmd, shell=True, env=env,
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -40,14 +43,14 @@ def run_cmd(cmd, localised=False):
     return stdout, stderr, returncode
 
 
-def run_cmd_log(cmd, localised=False):
+def run_cmd_log(cmd, localised=False, unsudo=False):
     '''
     Wrapper against run_cmd but Kano Logging executuion and return code
     '''
 
     from kano.logging import logger
 
-    out, err, rv = run_cmd(cmd, localised)
+    out, err, rv = run_cmd(cmd, localised, unsudo)
     logger.info("Command: {}".format(cmd))
 
     if len(out.strip()) > 0:
@@ -61,13 +64,16 @@ def run_cmd_log(cmd, localised=False):
     return out, err, rv
 
 
-def run_bg(cmd, localised=False):
+def run_bg(cmd, localised=False, unsudo=False):
     '''
     Starts cmd program in the background
     '''
     env = os.environ.copy()
     if not localised:
         env['LC_ALL'] = 'C'
+
+    if unsudo and 'SUDO_USER' in os.environ and os.environ['SUDO_USER'] != 'root':
+        cmd = "sudo -u {} bash -c '{}' ".format(os.environ['SUDO_USER'], cmd)
 
     s=subprocess.Popen(cmd, shell=True, env=env)
     return s


### PR DESCRIPTION
This PR adds an 'unsudo' option to run_cmd, run_cmd_log, run_cmd_bg to allow running as the
original user. This is to avoid running things unnecessrily as root which can result in files
being owned as root.

It also bumps the revision since this will need to be used in other packages.