### PR TITLE
Add module for app initialisation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (2.0-2) unstable; urgency=low
+
+  * Add app module
+
+ -- Team Kano <dev@kano.me>  Thu, 4 Jun 2015 16:00:00 +0100
+
 kano-toolset (2.0-1) unstable; urgency=low
 
   * Adding the get_free_space() function to utils

--- a/kano/app.py
+++ b/kano/app.py
@@ -1,0 +1,25 @@
+#
+# app.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Utilities for executable scripts
+#
+
+import os
+import sys
+
+def init_env(app_name, bin_path):
+    """
+    Initialise the environment for executables.
+    """
+
+    dir_path = os.path.abspath(os.path.join(
+        os.path.dirname(bin_path), '..'))
+
+    if dir_path != '/usr':
+        sys.path.insert(1, dir_path)
+        locale_path = os.path.join(dir_path, 'locale')
+    else:
+        locale_path = None


### PR DESCRIPTION
This module replaces the standard calls at the top of every executable
to add the local path to the list of directories for Python to search
through with:

 ```python
    from kano.app import init_env
    init_env('app_name', __file__)
```

cc @pazdera @convolu @Ealdwulf @carolineclark @alex5imon  