### PR TITLE
Adding support for Internet status via a regular text file

### DIFF
--- a/bin/kano-network-hook
+++ b/bin/kano-network-hook
@@ -17,6 +17,9 @@ import time
 from kano.logging import logger
 from kano.utils import get_cpu_id, get_rpi_model, run_cmd
 
+# file that external applications can monitor for internet availability triggers
+monitor_file="/var/opt/internet_monitor"
+
 def send_cpu_id():
     sent=False
 
@@ -48,7 +51,14 @@ def send_cpu_id():
 
 if __name__ == '__main__':
     rc = 1
+
+    # A DHCP BOUND event is an indication that the Internet should be reachable
     if len(sys.argv) > 1 and sys.argv[1] == 'bound':
+
+        # update internet availability info
+        with open(monitor_file, 'w') as f:
+            f.write('internet: up\n')
+
         if send_cpu_id() == True:
             logger.info('Kit serial number has been sent')
             rc=0

--- a/debian/kano-toolset.install
+++ b/debian/kano-toolset.install
@@ -12,6 +12,8 @@ uinput/scancodes.py usr/lib/python2.7/dist-packages/
 
 udhcpc/kano.script etc/udhcpc
 
+ifplugd/kano-ifplugd etc/ifplugd/action.d
+
 bash/logging.sh usr/share/kano-toolset/
 bash/logging_py.sh usr/share/kano-toolset/
 

--- a/ifplugd/kano-ifplugd
+++ b/ifplugd/kano-ifplugd
@@ -5,14 +5,14 @@
 # Copyright (C) 2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
-# This script is called when network DHCP events occur
-# It is called from /etc/udhcpc/kano.script (Kano Toolset packge)
-# and sends the RaspberryPI CPU Serial Number to Kano. It runs as the superuser.
+# This script is called by the ifplugd deamone when network interfaces
+# transition from UP and DOWN (connected to disconnected).
 #
-# Monitors the link status of the Internet through an external regular file
+# For ethernet devices it is detected when you plug / unplug the network cable.
+# On wireless devices the (de)association from the access point.
 #
-# Listens for DOWN events only, if the Internet is down, puts a mark in the external file.
-# UP events are recorded from the kano-network-hook, because they have a much higher latency.
+# The UP event is controlled by kano-network-hook script, because it is called
+# after the DHCP client has setup the correct configuration.
 #
 
 # file that external applications can monitor for internet availability triggers

--- a/ifplugd/kano-ifplugd
+++ b/ifplugd/kano-ifplugd
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# kano-ifplugd
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# This script is called when network DHCP events occur
+# It is called from /etc/udhcpc/kano.script (Kano Toolset packge)
+# and sends the RaspberryPI CPU Serial Number to Kano. It runs as the superuser.
+#
+# Monitors the link status of the Internet through an external regular file
+#
+# Listens for DOWN events only, if the Internet is down, puts a mark in the external file.
+# UP events are recorded from the kano-network-hook, because they have a much higher latency.
+#
+
+# file that external applications can monitor for internet availability triggers
+monitor_file="/var/opt/internet_monitor"
+
+if [ "$2" == "down" ]; then
+
+    # We are testing internet connectivity now for if we are in multihomed mode (eth and wlan)
+    is_internet
+    if [ "$?" != "0" ]; then
+	echo -e "internet: down\n" > $monitor_file
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
 * Script changes for UDHCP hook, and new ifplugd script are provided,
   which will maintain an external regular file to monitor the internet status
 * The file can then be monitored for changes as a trigger (lxpanel status, etc)
