### PR TITLE
Gtk: Remove unnecessary padding from LabelledEntries

### DIFF
--- a/kano/gtk3/labelled_entries.py
+++ b/kano/gtk3/labelled_entries.py
@@ -14,7 +14,6 @@ class LabelledEntries(Gtk.Alignment):
 
     def __init__(self, entries_info):
         Gtk.Alignment.__init__(self)
-        self.set_padding(0, 0, 0, 100)
 
         self.box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.entries = []


### PR DESCRIPTION
KanoComputing/peldins#1883
The LabelledEntries class introduced a margin which maligns any centring
of the widget.

cc @pazdera @carolineclark @convolu 