### PR TITLE
Logging: Fix flush and sync functions

### DIFF
--- a/kano/logging.py
+++ b/kano/logging.py
@@ -197,7 +197,7 @@ class Logger:
                     sys.stderr.write(output_line)
 
     def sync(self):
-        self._log_file.flush()
+        self.flush()
 
     def error(self, msg, **kwargs):
         kwargs["level"] = "error"
@@ -216,8 +216,9 @@ class Logger:
         self.write(msg, **kwargs)
 
     def flush(self):
-        if self._log_file:
-            self._log_file.close()
+        if self._log_file and not self._log_file.closed:
+            self._log_file.flush()
+
         sys.stderr.flush()
 
     def _init_log_file(self):


### PR DESCRIPTION
When `flush()`ing the log, it would close the file if one existed,
rather than flushing the file. It would also flush the `stderr`.

`sync`, on the other hand, would `flush()` the log file regardless of
whether it was open but would not flush the `stderr`.

Merge these two functions but retain both interfaces, ensuring that the
log file is open before flushing, flush the `stderr` and don't close the
file in any circumstance.

cc @pazdera 