### PR TITLE
Timeout

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,15 @@
+kano-toolset (2.1-1) unstable; urgency=low
+
+  * Adding the kano.timeout module
+
+ -- Team Kano <dev@kano.me>  Wed, 1 Jul 2015 16:26:00 +0100
+
 kano-toolset (2.0-2) unstable; urgency=low
 
   * Add 'unsudo' option to run_cmd, run_cmd_bg, run_cmd_log
 
  -- Team Kano <dev@kano.me>  Tue, 15 May 2015 18:59:00 +0100
+
 kano-toolset (2.0-1) unstable; urgency=low
 
   * Adding the get_free_space() function to utils

--- a/kano/timeout.py
+++ b/kano/timeout.py
@@ -1,5 +1,8 @@
 # The timeout decorator
 #
+# Copyright (C) 2015 Kano Computing Ltd.
+# License:   http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
 # Allows to run functions with a specified timeout easily.
 #
 # Source:
@@ -18,8 +21,10 @@ import errno
 import os
 import signal
 
+
 class TimeoutError(Exception):
     pass
+
 
 def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
     def decorator(func):

--- a/kano/timeout.py
+++ b/kano/timeout.py
@@ -1,0 +1,40 @@
+# The timeout decorator
+#
+# Allows to run functions with a specified timeout easily.
+#
+# Source:
+#   http://stackoverflow.com/questions/2281850/timeout-function-if-it-takes-too-long-to-finish
+#
+# Usage:
+#
+#   @timeout(10) #seconds
+#   def your_function(a, b):
+#       ...
+#
+#   The function will be interrupted after the specified timeout
+
+from functools import wraps
+import errno
+import os
+import signal
+
+class TimeoutError(Exception):
+    pass
+
+def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
+    def decorator(func):
+        def _handle_timeout(signum, frame):
+            raise TimeoutError(error_message)
+
+        def wrapper(*args, **kwargs):
+            signal.signal(signal.SIGALRM, _handle_timeout)
+            signal.alarm(seconds)
+            try:
+                result = func(*args, **kwargs)
+            finally:
+                signal.alarm(0)
+            return result
+
+        return wraps(func)(wrapper)
+
+    return decorator


### PR DESCRIPTION
Adding the timeout decorator to be used from `notifications.py`.

If there isn't anything at the other end of the pipe, writing into it will block forever. This will be helpful to fix that.

cc @alex5imon @tombettany 