### PR TITLE
Changes for the new updater

### DIFF
--- a/bin/kano-dialog
+++ b/bin/kano-dialog
@@ -24,7 +24,7 @@ from kano.utils import is_number
 
 def main():
     text = sys.argv[1:]
-    title, description, buttons, custom_widget, entry_bool, list_bool, scrolled_text, global_style = parse_items(text)
+    title, description, buttons, custom_widget, entry_bool, list_bool, scrolled_text, global_style, hide_from_taskbar = parse_items(text)
     kdialog = KanoDialog(
         title_text=title,
         description_text=description,
@@ -33,7 +33,8 @@ def main():
         has_entry=entry_bool,
         has_list=list_bool,
         scrolled_text=scrolled_text,
-        global_style=global_style)
+        global_style=global_style,
+        hide_from_taskbar=hide_from_taskbar)
     response = kdialog.run()
 
     # Printing out response means we can read the return value in bash via

--- a/bin/kano-shutdown
+++ b/bin/kano-shutdown
@@ -9,13 +9,9 @@
 # The user executing this code needs sudo NOPASSWD: privileges for /sbin/poweroff.
 #
 
-# Check if the updater scheduled the install at shutdown
-STATUS_FILE="/var/cache/kano-updater/status.json"
-scheduled=`grep -Po '"is_scheduled":.[0|1]' $STATUS_FILE | awk '{ print $2 }'`
 
-if [ $scheduled -eq 1 ]; then
-    sudo kano-updater install --gui
-fi
+# run the updater to install urgent or prompt for updating now
+sudo kano-updater install ui shutdown-window
 
 # Report shutdown event to Kano Tracker
 kano-tracker-ctl +1 shutdown

--- a/bin/kano-shutdown
+++ b/bin/kano-shutdown
@@ -11,7 +11,7 @@
 
 
 # run the updater to install urgent or prompt for updating now
-sudo kano-updater install ui shutdown-window
+sudo kano-updater ui shutdown-window
 
 # Report shutdown event to Kano Tracker
 kano-tracker-ctl +1 shutdown

--- a/bin/kano-shutdown
+++ b/bin/kano-shutdown
@@ -9,6 +9,15 @@
 # The user executing this code needs sudo NOPASSWD: privileges for /sbin/poweroff.
 #
 
+# Check if the updater scheduled the install at shutdown
+STATUS_FILE="/var/cache/kano-updater/status.json"
+scheduled=`grep -Po '"is_scheduled":.[0|1]' $STATUS_FILE | awk '{ print $2 }'`
+
+if [ $scheduled -eq 1 ]
+then
+    sudo kano-updater install --gui
+fi
+
 # Report shutdown event to Kano Tracker
 kano-tracker-ctl +1 shutdown
 

--- a/bin/kano-shutdown
+++ b/bin/kano-shutdown
@@ -13,8 +13,7 @@
 STATUS_FILE="/var/cache/kano-updater/status.json"
 scheduled=`grep -Po '"is_scheduled":.[0|1]' $STATUS_FILE | awk '{ print $2 }'`
 
-if [ $scheduled -eq 1 ]
-then
+if [ $scheduled -eq 1 ]; then
     sudo kano-updater install --gui
 fi
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (2.1-2) unstable; urgency=low
+
+  * Adding scheduling functionality for Kano Updater
+
+ -- Team Kano <dev@kano.me>  Mon, 14 Sep 2015 14:10:00 +0100
+
 kano-toolset (2.1-1) unstable; urgency=low
 
   * Adding the kano.timeout module

--- a/kano/gtk3/kano_dialog.py
+++ b/kano/gtk3/kano_dialog.py
@@ -39,7 +39,7 @@ class KanoDialog():
     # It can either be a dictionary for backwards compatibility, or a list
     def __init__(self, title_text="", description_text="", button_dict=None, widget=None,
                  has_entry=False, has_list=False, scrolled_text="", global_style="", parent_window=None,
-                 orange_info=None):
+                 orange_info=None, hide_from_taskbar=False):
 
         self.title_text = title_text
         self.description_text = description_text
@@ -57,6 +57,7 @@ class KanoDialog():
         self.dialog.set_decorated(False)
         self.dialog.set_resizable(False)
         self.dialog.set_keep_above(True)
+        self.dialog.set_skip_taskbar_hint(hide_from_taskbar)
         self.dialog.set_border_width(5)
 
         apply_styling_to_widget(self.dialog, self.CSS_PATH)
@@ -269,6 +270,7 @@ def parse_items(args):
     has_list = False
     buttons = {}
     global_style = False
+    hide_from_taskbar = False
 
     for arg in args:
         split = arg.split('=')
@@ -324,7 +326,10 @@ def parse_items(args):
         if split[0] == "global_style":
             global_style = True
 
-    return title, description, buttons, widget, has_entry, has_list, scrolled_text, global_style
+        if split[0] == "no-taskbar":
+            hide_from_taskbar = True
+
+    return title, description, buttons, widget, has_entry, has_list, scrolled_text, global_style, hide_from_taskbar
 
 
 def on_button_toggled(button):


### PR DESCRIPTION
* Add option to `kano-dialog` to Remove the taskbar entry of it
* Call the updater on shutdown to handle scheduled updates
* Bump package version to 2.1-2