### PR TITLE
Send the ping event on every boot

### DIFF
--- a/bin/kano-network-hook
+++ b/bin/kano-network-hook
@@ -23,6 +23,14 @@ monitor_file="/var/opt/internet_monitor"
 def send_cpu_id():
     sent=False
 
+    # This is a loose dependency as we can't make kano-toolset
+    # depend on profile.
+    try:
+        from kano_profile.tracking_events import generate_event
+        generate_event('ping')
+    except Exception as e:
+        logger.error("Error sending the ping event ({})".format(e))
+
     # Get the unit CPU Serial number and send it, save a local copy
     cpuid_filename = '/etc/cpuid-{}'.format(get_cpu_id())
     if os.path.isfile(cpuid_filename):
@@ -30,14 +38,6 @@ def send_cpu_id():
         pass
     else:
         try:
-            # This is a loose dependency as we can't make kano-toolset
-            # depend on profile.
-            try:
-                from kano_profile.tracker_events import generate_event
-                generate_event('ping')
-            except Exception as e:
-                logger.error("Error sending the ping event ({})".format(e))
-
             # The code below is the legacy way of tracking cpuids
             # TODO: To be removed when the new way is known to be reliable
 


### PR DESCRIPTION
Part of the unreliability of the process is that we only send it once. So if the server rejects it for some reason (a bug in the API) we will have lost the event forever. This changes it to happen on every connection to a network.

cc @alex5imon @skarbat 