### PR TITLE
Add open_locked() from kano-profile as it is generally useful.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (2.2.0-1) unstable; urgency=low
+
+  * Adding open_locked API.
+
+ -- Team Kano <dev@kano.me>  Mon, 14 Sep 2015 14:10:00 +0100
+
 kano-toolset (2.1-2) unstable; urgency=low
 
   * Adding scheduling functionality for Kano Updater

--- a/kano/utils.py
+++ b/kano/utils.py
@@ -584,3 +584,13 @@ def get_free_space(path="/"):
     device, size, used, free, percent, mp = out.split('\n')[1].split()
 
     return int(free) / 1024
+
+
+class open_locked(file):
+    """ A version of open with an exclusive lock to be used within
+        controlled execution statements.
+    """
+    def __init__(self, *args, **kwargs):
+        super(open_locked, self).__init__(*args, **kwargs)
+        fcntl.flock(self, fcntl.LOCK_EX)
+

--- a/kano/utils.py
+++ b/kano/utils.py
@@ -20,7 +20,7 @@ import getpass
 import pwd
 import grp
 import json
-
+import fcntl
 
 def run_cmd(cmd, localised=False, unsudo=False):
     '''
@@ -591,6 +591,16 @@ class open_locked(file):
         controlled execution statements.
     """
     def __init__(self, *args, **kwargs):
-        super(open_locked, self).__init__(*args, **kwargs)
-        fcntl.flock(self, fcntl.LOCK_EX)
+        """
+        pass optional nonblock=True for nonblocking behavior
+        """
 
+        # we need to process 'nonblock' before calling
+        # super().__init__ because that does not know about 'nonblock'
+        mode = fcntl.LOCK_EX
+        if kwargs.get('nonblock') is not None:
+            mode = mode | fcntl.LOCK_NB
+            del kwargs['nonblock']
+
+        super(open_locked, self).__init__(*args, **kwargs)
+        fcntl.flock(self, mode)


### PR DESCRIPTION
This PR adds @pazdera's `open_locked` from kano-profile.tracker to kano-toolset, as I want to use it in kano-settings.boot_config
I know, andother api in kano.utils. However, we need to split it anyway and I'm not about to do so at this point.
@pazdera @tombettany 
Will rebase jessie branch once this is merged.  
