### PR TITLE
ifplugd: Flush IP addresses when connection is lost

### DIFF
--- a/ifplugd/kano-ifplugd
+++ b/ifplugd/kano-ifplugd
@@ -17,6 +17,7 @@
 
 # file that external applications can monitor for internet availability triggers
 monitor_file="/var/opt/internet_monitor"
+interface="$1"
 
 if [ "$2" == "down" ]; then
 
@@ -25,6 +26,9 @@ if [ "$2" == "down" ]; then
     if [ "$?" != "0" ]; then
 	echo -e "internet: down\n" > $monitor_file
     fi
+
+    # Clear associated IP addresses
+    ip addr flush dev $interface
 fi
 
 exit 0


### PR DESCRIPTION
When a network interface goes down, the IP addresses associated with
that interface are retained. This leads to troubles for applications
which use the IP address to determine connectivity. Resolve this by
flushing all the associated IP addresses when the interface is detected
as down.

@convolu @Ealdwulf @skarbat @pazdera Do you see any ramifications
from doing this?

@alex5imon This resolves the Make Art long waiting time problem.