### PR TITLE
Decorators: Add module for useful decorators

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (2.2.0-3) unstable; urgency=low
+
+  * Add decorators module.
+
+ -- Team Kano <dev@kano.me>  Wed, 6 Jan 2016 16:17:00 +0100
+
 kano-toolset (2.2.0-2) unstable; urgency=low
 
   * Adding get_partition_info API.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-kano-toolset (2.2.0-3) unstable; urgency=low
+kano-toolset (2.3.0-1) unstable; urgency=low
 
   * Add decorators module.
 

--- a/kano/decorators.py
+++ b/kano/decorators.py
@@ -37,7 +37,7 @@ def require_root(exit_on_failure=False, verbose=False):
                 logger.error(msg)
 
                 if verbose:
-                    print msg
+                    sys.stdout.write('{}\n'.format(msg))
 
                 if exit_on_failure:
                     sys.exit(ERR_ROOT_PERMISSIONS_REQ)

--- a/kano/decorators.py
+++ b/kano/decorators.py
@@ -7,14 +7,45 @@
 
 
 import os
+import sys
 from kano.logging import logger
 
-def require_root(func):
-    def ensure_root():
-        if not os.getuid() == 0:
-            logger.error('You need to run this option as root, try with sudo')
-            return False
+ERR_ROOT_PERMISSIONS_REQ = -1
 
-        return func()
 
-    return ensure_root
+def require_root(exit_on_failure=False, verbose=False):
+    '''
+    Generates decorator to enforce root permissions
+
+    NB: must be called when used as decorator, i.e.
+        @require_root()
+        def my_func():
+            pass
+
+    @params  exit_on_failure   Quit application on failure
+    @params  verbose           Print messages to stdout
+    '''
+
+    def require_root_decorator(func):
+        '''
+        Actual decorator that gets applied to functions
+        '''
+
+        def ensure_root(*args, **kwargs):
+            if os.getuid() != 0:
+                msg = 'You need to run this option as root, try with sudo'
+                logger.error(msg)
+
+                if verbose:
+                    print msg
+
+                if exit_on_failure:
+                    sys.exit(ERR_ROOT_PERMISSIONS_REQ)
+
+                return False
+
+            return func(*args, **kwargs)
+
+        return ensure_root
+
+    return require_root_decorator

--- a/kano/decorators.py
+++ b/kano/decorators.py
@@ -1,0 +1,20 @@
+# decorators.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Decorators used to simplify control and ease modularity
+
+
+import os
+from kano.logging import logger
+
+def require_root(func):
+    def ensure_root():
+        if not os.getuid() == 0:
+            logger.error('You need to run this option as root, try with sudo')
+            return False
+
+        return func()
+
+    return ensure_root


### PR DESCRIPTION
Decorators are very powerful and there are often occasions where a
decorator can be reused by multiple packages. Add a first decorator for
`require_root` to the module.

Taken out of KanoComputing/make-light#180.

Supersedes https://github.com/KanoComputing/kano-toolset/pull/166