### PR TITLE
Utils: Fix circular dependency caused by separation

### DIFF
--- a/kano/utils/__init__.py
+++ b/kano/utils/__init__.py
@@ -23,11 +23,12 @@ from kano.utils.hardware import \
     detect_kano_keyboard, is_model_a, is_model_b, is_model_b_plus, \
     is_model_2_b, get_rpi_model, is_monitor, get_mac_address, get_cpu_id
 from kano.utils.processes import \
-    kill_child_processes, is_running, get_program_name, pkill, restore_signals
+    kill_child_processes, is_running, get_program_name, pkill
 from kano.utils.gui import \
     is_gui, zenity_show_progress
 from kano.utils.shell import \
-    run_cmd, run_cmd_log, run_bg, run_term_on_error, run_print_output_error
+    run_cmd, run_cmd_log, run_bg, run_term_on_error, run_print_output_error, \
+    restore_signals
 from kano.utils.http_requests import \
     proxies, download_url, requests_get_json, debug_requests
 from kano.utils.disk import \

--- a/kano/utils/gui.py
+++ b/kano/utils/gui.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from kano.utils.processes import restore_signals
+from kano.utils.shell import restore_signals
 
 
 def is_gui():

--- a/kano/utils/processes.py
+++ b/kano/utils/processes.py
@@ -46,10 +46,3 @@ def pkill(clues):
             if clue in line:
                 pid = line.split()[0]
                 run_cmd("kill {}".format(pid))
-
-
-def restore_signals():
-    signals = ('SIGPIPE', 'SIGXFZ', 'SIGXFSZ')
-    for sig in signals:
-        if hasattr(signal, sig):
-            signal.signal(getattr(signal, sig), signal.SIG_DFL)

--- a/kano/utils/shell.py
+++ b/kano/utils/shell.py
@@ -1,8 +1,14 @@
 import os
 import sys
+import signal
 import subprocess
 
-from kano.utils.processes import restore_signals
+def restore_signals():
+    signals = ('SIGPIPE', 'SIGXFZ', 'SIGXFSZ')
+    for sig in signals:
+        if hasattr(signal, sig):
+            signal.signal(getattr(signal, sig), signal.SIG_DFL)
+
 
 def run_cmd(cmd, localised=False, unsudo=False):
     '''


### PR DESCRIPTION
When separating Kano Utils into submodules, a circular dependency
between the `shell.py` and `process.py` modules was created. Resolve
this by migrating the offending code to be contained in just the `shell`
module.

Thanks to @Ealdwulf for pointing this out. Could you take a look?