### PR TITLE
Fixing is_systemd function

### DIFF
--- a/kano/utils/system.py
+++ b/kano/utils/system.py
@@ -1,3 +1,5 @@
+import os
+
 def is_jessie():
     '''
     Returns True if /etc/debian_version tells us


### PR DESCRIPTION
 * A missing import was generating an exception which made
   is_systemd() to always return False.

cc @pazdera @Ealdwulf 
