### PR TITLE
Fixed get_volume call to updated version

### DIFF
--- a/kano/utils/audio.py
+++ b/kano/utils/audio.py
@@ -24,7 +24,7 @@ def play_sound(audio_file, background=False):
     if extension in ['.wav', '.voc', '.raw', '.au']:
         cmd = 'aplay -q {}'.format(audio_file)
     else:
-        volume_percent, _ = get_volume()
+        volume_percent = get_volume()
         volume_str = '--vol {}'.format(
             percent_to_millibel(volume_percent, raspberry_mod=True))
         cmd = 'omxplayer -o both {volume} {link}'.format(


### PR DESCRIPTION
The `get_volume()` function was updated to only return the volume percentage [here](https://github.com/KanoComputing/kano-toolset/pull/171). This particular call was missed. Sorry :(

@tombettany @convolu free to merge?