### PR TITLE
Gtk Button: Fix Gtk warnings when starting/stopping the spinner

### DIFF
--- a/kano/gtk3/buttons.py
+++ b/kano/gtk3/buttons.py
@@ -116,6 +116,9 @@ class KanoButton(GenericButton):
         apply_styling_to_widget(self.spinner, self.SPINNER_CSS)
 
     def start_spinner(self):
+        if self.is_spinning:
+            return
+
         # Keep old dimensions with box
         allocation = self.get_allocation()
         self.remove(self.internal_box)
@@ -132,6 +135,9 @@ class KanoButton(GenericButton):
 
     # Replace content of button with original content and stop spinner spinning
     def stop_spinner(self):
+        if not self.is_spinning:
+            return
+
         self.spinner.stop()
         self.remove(self.spinner)
         self.add(self.internal_box)


### PR DESCRIPTION
When the spinner is triggered multiple times without stopping between
or stopped when it hasn't been started (as may happen during some
initialisations), Gtk warnings appear warning of

```
Gtk-CRITICAL **: gtk_container_remove:
    assertion 'gtk_widget_get_parent (widget) == GTK_WIDGET (container)
               || GTK_IS_ASSISTANT (container)
               || GTK_IS_ACTION_BAR (container)' failed
```

and

```
Gtk-WARNING **:
    Attempting to add a widget with type GtkBox to a container of type
    kano+gtk3+buttons+KanoButton, but the widget is already inside a
    container of type kano+gtk3+buttons+KanoButton, please use
    gtk_widget_reparent()
```

Prevent these situations occurring by adding guards to the start and
stop functions.

Supersedes https://github.com/KanoComputing/kano-toolset/pull/160