### PR TITLE
Signal launch share

### DIFF
--- a/bin/kano-signal
+++ b/bin/kano-signal
@@ -91,8 +91,18 @@ fi
 
 # if there is no pipe, webkit is not running
 if [ -p $pipe_name ]; then
-    # webkit is running
+    # Minecraft and Pong, because webkit is running.
     echo $jscmd > $pipe_name
+
+    # Since this is a signal from another app (most times Kano World),
+    # switch user focus back to the game app.
+    if [ "$app" == "make-minecraft" ]; then
+	wmctrl -a "Make Minecraft"
+    fi
+
+    if [ "$app" == "make-pong" ]; then
+	wmctrl -a "Make Pong"
+    fi
 else
     # Pass on event to dbus
     # In the case of launch-share, we send the xml file as an extra string parameter on the signal
@@ -103,6 +113,8 @@ else
 	dbus-send --session --dest="me.kano.$app" --print-reply \
 		  "/me/kano/$app" "me.kano.$app.Actions.$signal" 2>/dev/null
     fi
+
+    # TODO: Apps should implement gaining focus when such signal is sent
 fi
 
 exit 0

--- a/bin/kano-signal
+++ b/bin/kano-signal
@@ -12,22 +12,23 @@
 # to point to your desktop.
 #
 # It is also invoked from Kano World when launching a Share.
-# The chromium hooks connect to kano-profile.apps module,
-# it calls this script with "launch-share <filename>,
-# which will open a share on the currently running app.
+# The chromium hook connected to kano-profile.apps module,
+# calls this script with "launch-share <xml_filename>",
+# which will open a share on the currently running app by sending a signal.
 #
-# Exit code 0 means the signal could be delivered, any other value means error.
+# Exit code 0 means the signal could be delivered, any other value means error,
+# in which case you should launch the app.
 #
 
 # pipe name to send javascript code
 pipe_name=/tmp/webapp.pipe
 app=""
 
+# signal name
 signal=$1
 
-# For launch-share signal
+# "launch-share" signal name needs this extra parameter
 xml_filename=$2
-
 
 # syntax sanity check
 case $signal in
@@ -63,12 +64,13 @@ esac
 
 
 function is_running {
-    xwininfo -tree -root | grep -i $1 > /dev/null 2>&1
+    xwininfo -tree -root | grep -i "$1" > /dev/null 2>&1
+    xwininfo -tree -root | grep -i "$1" >> $logfile
 }
 
 
 # TODO: We need to cover the rest of Kano apps (see kano-profile/rules)
-for APP in pong minecraft music; do
+for APP in make-pong make-minecraft make-music; do
     is_running $APP
     if [ $? == 0 ]; then
         app=$APP
@@ -84,6 +86,7 @@ done
 
 if [ -z $app ]; then
     # No valid app is running
+    echo "no valid app is running, returning error"
     exit 1
 fi
 

--- a/bin/kano-signal
+++ b/bin/kano-signal
@@ -2,14 +2,21 @@
 
 # kano-signal
 #
-# Copyright (C) 2014 Kano Computing Ltd.
+# Copyright (C) 2014-2016 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
-# Sends a signal to a Kano app (save, load, share, make)
+# Sends a signal to a Kano app (save, load, share, make, launch-share)
 #
 # This script is invoked by the Kano Keyboard hotkeys (xbindkeys in Kano Desktop).
 # If you call it from a shell or command line, make sure you export DISPLAY
 # to point to your desktop.
+#
+# It is also invoked from Kano World when launching a Share.
+# The chromium hooks connect to kano-profile.apps module,
+# it calls this script with "launch-share <filename>,
+# which will open a share on the currently running app.
+#
+# Exit code 0 means the signal could be delivered, any other value means error.
 #
 
 # pipe name to send javascript code
@@ -17,6 +24,9 @@ pipe_name=/tmp/webapp.pipe
 app=""
 
 signal=$1
+
+# For launch-share signal
+xml_filename=$2
 
 
 # syntax sanity check
@@ -33,8 +43,20 @@ case $signal in
     make)
         jscmd="Signal.make()"
         ;;
+
+    launch-share)
+	# Make sure the share creation was downloaded
+	if [ ! -f "$xml_filename" ]; then
+	    echo "Please specify a valid xml file to 'launch-share' : $xml_filename"
+	    exit 1
+	fi
+
+	# Command to open a share on top of your current workspace
+        jscmd="Signal.launch_share(\"$xml_filename\")"	
+        ;;
+
     *)
-        echo "Usage: make-signal < save | load | share | make >"
+        echo "Usage: make-signal < save | load | share | make | launch-share <xml_filename> >"
         exit 1
         ;;
 esac
@@ -45,6 +67,7 @@ function is_running {
 }
 
 
+# TODO: We need to cover the rest of Kano apps (see kano-profile/rules)
 for APP in pong minecraft music; do
     is_running $APP
     if [ $? == 0 ]; then
@@ -64,20 +87,20 @@ if [ -z $app ]; then
     exit 1
 fi
 
-
-if [ "$2" == "debug" ]; then
-    echo "Dispatching signal: $signal"
-fi
-
-
 # if there is no pipe, webkit is not running
 if [ -p $pipe_name ]; then
     # webkit is running
     echo $jscmd > $pipe_name
 else
     # Pass on event to dbus
-    dbus-send --session --dest="me.kano.$app" --print-reply \
-              "/me/kano/$app" "me.kano.$app.Actions.$signal" 2>/dev/null
+    # In the case of launch-share, we send the xml file as an extra string parameter on the signal
+    if [ "$signal" == "launch-share" ]; then
+	dbus-send --session --dest="me.kano.$app" --print-reply \
+		  "/me/kano/$app" "me.kano.$app.Actions.$signal string:\"$xml_filename\"" 2>/dev/null
+    else
+	dbus-send --session --dest="me.kano.$app" --print-reply \
+		  "/me/kano/$app" "me.kano.$app.Actions.$signal" 2>/dev/null
+    fi
 fi
 
-exit $?
+exit 0

--- a/bin/kano-signal
+++ b/bin/kano-signal
@@ -53,7 +53,7 @@ case $signal in
 	fi
 
 	# Command to open a share on top of your current workspace
-        jscmd="Signal.launch_share(\"$xml_filename\")"	
+        jscmd="Signal.load(\"$xml_filename\")"
         ;;
 
     *)
@@ -65,7 +65,6 @@ esac
 
 function is_running {
     xwininfo -tree -root | grep -i "$1" > /dev/null 2>&1
-    xwininfo -tree -root | grep -i "$1" >> $logfile
 }
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-kano-toolset (2.4.0-4) unstable; urgency=low
+kano-toolset (2.3.0-5) unstable; urgency=low
 
   * Added option for kano-signal to open new projects (launch-share)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ kano-toolset (2.3.0-5) unstable; urgency=low
 
   * Added option for kano-signal to open new projects (launch-share)
 
- -- Team Kano <dev@kano.me>  Thu, 15 Jan 2016 14:32:00 +0100
+ -- Team Kano <dev@kano.me>  Thu, 19 Jan 2016 15:11:00 +0100
 
 kano-toolset (2.3.0-4) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (2.4.0-4) unstable; urgency=low
+
+  * Added option for kano-signal to open new projects (launch-share)
+
+ -- Team Kano <dev@kano.me>  Thu, 15 Jan 2016 14:32:00 +0100
+
 kano-toolset (2.3.0-4) unstable; urgency=low
 
   * Add 'timeout' keyword arg to open_locked

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: kano-toolset
 Architecture: all
 Depends: ${misc:Depends}, python-gtk2, python-webkit,
          fping, python, zenity, bc, ifplugd, python-yaml, python-pyinotify,
-         resolvconf, libpng12-0, libraspberrypi-bin, procps, x11-utils, dbus
+         resolvconf, libpng12-0, libraspberrypi-bin, procps, x11-utils, dbus, wmctrl
 Replaces: kano-init (<< 1.0-46)
 Breaks: kano-init (<< 1.0-46)
 Description: Collection of tools for Kanux


### PR DESCRIPTION
Provide a new option to `kano-signal` to open projects without starting a new app instance.
