### PR TITLE
Implement open share signal for Make Art

### DIFF
--- a/bin/kano-signal
+++ b/bin/kano-signal
@@ -28,6 +28,7 @@ from optparse import OptionParser
 
 # verbose flag for debugging on the console
 verbose=False
+dry_run=False
 
 # pipe name to send javascript code
 pipe_name = "/tmp/webapp.pipe"
@@ -46,7 +47,8 @@ def set_focus(app, verbose=False):
         'make-minecraft': 'Make Minecraft',
         'make-pong': 'Make Pong',
         'sonicpi': 'Sonic Pi',
-        'make-light': 'Make Light'
+        'make-light': 'Make Light',
+        'kano-draw': 'Art'
     }
 
     if app in app_titles_dict:
@@ -71,13 +73,17 @@ if __name__ == '__main__':
     share_filename=None
 
     usage_help='Usage: kano-signal < save | load | share | make | ' \
-      'launch-share <share_filename> > [ --verbose ]'
+      'launch-share <share_filename> > [ --verbose ] [ --dry-run ]'
 
     # Collect arguments, first one is the signal name, optional "verbose"
     parser = OptionParser()
     parser.add_option('-v', '--verbose',
                 action='store_true', dest='verbose', default=False,
                 help='Be verbose', metavar="FILE")
+
+    parser.add_option('-d', '--dry-run',
+                action='store_true', dest='dry_run', default=False,
+                help='Only explain what would be done', metavar="FILE")
 
     (options, args) = parser.parse_args()
     verbose=options.verbose
@@ -88,11 +94,12 @@ if __name__ == '__main__':
     else:
         # sanity check
         signal=args[0]
-        if signal == 'launch-share' and len(args) < 2:
-            print 'Please specify a Kano World share file to open'
-            sys.exit(1)
-        else:
-            share_filename=args[1]
+        if signal == 'launch-share':
+            if len(args) < 2:
+                print 'Please specify a Kano World share file to open'
+                sys.exit(1)
+            else:
+                share_filename=args[1]
 
     # Prepare signal based on arguments received
     if signal == "save":
@@ -109,7 +116,7 @@ if __name__ == '__main__':
 
         # Make sure the kano world share creation was downloaded
         if not os.path.exists(share_filename):
-            print "Please specify a valid xml file to 'launch-share' : {}".format(share_filename)
+            print "Please specify a valid share file to 'launch-share' : {}".format(share_filename)
             sys.exit(1)
 
         # Command to open a share on top of your current workspace
@@ -118,8 +125,13 @@ if __name__ == '__main__':
         print usage_help
         sys.exit(1)
 
+
+    if verbose:
+        print 'Receiving signal: {} - share_filename: {}'.format(signal, share_filename)
+
+
     # TODO: We need to cover the rest of Kano apps (see kano-profile/rules)
-    for APP in ["make-pong", "make-minecraft", "make-music", "make-light"]:
+    for APP in ["make-pong", "make-minecraft", "make-music", "make-light", "kano-draw"]:
         if is_running(APP):
             app = APP
             if app == "make-music":
@@ -132,6 +144,9 @@ if __name__ == '__main__':
         if verbose:
             print "no valid app is running, returning error"
         sys.exit(1)
+    else:
+        if verbose:
+            print 'Currently running app found: {}'.format(app)
 
     # if there is no pipe, webkit is not running
     fifo_exists = False
@@ -155,11 +170,17 @@ if __name__ == '__main__':
         # because kano-blocks webkit talks receives signals through the pipe.
         pipe = open(pipe_name, "w")
 
+        # FIXME: This is a special case for Kano Draw signal,
+        # temporary solution is to send a javasript code to redirect it to downloaded creation.
+        if app=='kano-draw':
+            jscmd='window.location="http://localhost:8000/localLoad/{}"'.format(share_filename.strip('/'))
+
         if verbose:
             print 'Sending app {} a webkit signal "{}"'.format(app, jscmd)
 
-        print >> pipe, jscmd
-        pipe.close()
+        if not dry_run:
+            print >> pipe, jscmd
+            pipe.close()
 
     else:
         # Pass on event to dbus
@@ -178,18 +199,19 @@ if __name__ == '__main__':
         if verbose:
             print 'Sending dbus signal {} to app {}, filename {}'.format(signal, app, share_filename)
 
-        try:
-            # In the case of launch-share, we send the share file as an extra string parameter on the signal
-            if signal == "load_share":
-                do_send_dbus(app, signal, share_filename)
-            else:
-                do_send_dbus(app, signal)
-        except:
-            # make sure to return 1 on error
-            import traceback
-            from kano.logging import logger
-            logger.error('Unexpected error when sending dbus signal.\n{}'
-                        .format(traceback.format_exc()))
-            sys.exit(1)
+        if not dry_run:
+            try:
+                # In the case of launch-share, we send the share file as an extra string parameter on the signal
+                if signal == "load_share":
+                    do_send_dbus(app, signal, share_filename)
+                else:
+                    do_send_dbus(app, signal)
+            except:
+                # make sure to return 1 on error
+                import traceback
+                from kano.logging import logger
+                logger.error('Unexpected error when sending dbus signal.\n{}'
+                            .format(traceback.format_exc()))
+                sys.exit(1)
 
 sys.exit(0)


### PR DESCRIPTION
 * Added detection of kano draw app on the desktop, and sending signal to open a share
 * Fixed parameter parsing issue for other signals (save/load/share/make)
 * Added a dry-run option to debug from the command line

cc @alex5imon @tombettany 
