### PR TITLE
Add an easy way of logging a handled exception.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (2.3.0-6) unstable; urgency=low
+
+  * Added simple way of logging an exception.
+
+ -- Team Kano <dev@kano.me>  Thu, 19 Jan 2016 15:11:00 +0100
+
 kano-toolset (2.3.0-5) unstable; urgency=low
 
   * Added option for kano-signal to open new projects (launch-share)

--- a/kano/logging.py
+++ b/kano/logging.py
@@ -175,6 +175,14 @@ class Logger:
             log.update(kwargs)
             log["level"] = lname
 
+            # if an exception object was passed in, add it to the log fields
+            tbk = None
+            if 'exception' in kwargs:
+                import traceback
+                tbk = traceback.format_exc()
+                log['exception'] = str(kwargs['exception'])
+                log['traceback'] = tbk
+
             for line in lines:
                 log["time"] = time.time()
                 log["message"] = line


### PR DESCRIPTION
This PR adds an 'exception' keyword arg to the loggiing methods. This can be passed an exception object and will add 'exception' and 'traceback' fields to the log json. This allows wone to write:
```
try:
   # risky code   
except Exception as e:
   logger.error('informative message',exception = e)
   # handle the exception
``` 
@radujipa @tombettany 