### PR TITLE
Hardware Utils: Add more board properties

### DIFF
--- a/kano/utils/hardware.py
+++ b/kano/utils/hardware.py
@@ -9,6 +9,15 @@
 from kano.utils.shell import run_cmd
 from kano.utils.file_operations import read_file_contents_as_lines
 
+RPI_A_KEY = 'RPI/A'
+RPI_A_PLUS_KEY = 'RPI/A+'
+RPI_B_BETA_KEY = 'RPI/B (Beta)'
+RPI_B_KEY = 'RPI/B'
+RPI_B_PLUS_KEY = 'RPI/B+'
+RPI_ZERO_KEY = 'RPI/Zero'
+RPI_COMPUTE_KEY = 'RPI/Compute'
+RPI_2_B_KEY = 'RPI/2/B'
+
 
 # "performance" scores for RPi boards
 RPI_A_SCORE = 1000
@@ -19,16 +28,78 @@ RPI_ZERO_SCORE = 3000
 RPI_COMPUTE_SCORE = 4000
 RPI_2_B_SCORE = 5000
 
-# "performance" scores lookup table with keys as given by get_rpi_model()
-PERFORMANCE_SCORES = {
-    'RPI/A': RPI_A_SCORE,
-    'RPI/A+': RPI_A_PLUS_SCORE,
-    'RPI/B': RPI_B_SCORE,
-    'RPI/B+': RPI_B_PLUS_SCORE,
-    'RPI/Zero': RPI_ZERO_SCORE,
-    'RPI/Compute': RPI_COMPUTE_SCORE,
-    'RPI/2/B': RPI_2_B_SCORE,
+RPI_1_CPU_PROFILE = 'rpi_1'
+RPI_2_CPU_PROFILE = 'rpi_2'
+
+
+'''
+Lookup table with keys as given by get_rpi_model() containing:
+    * Human readable 'name' of the board
+    * 'cpu_profile' which details the settings to use
+    * 'performance' scores
+'''
+BOARD_PROPERTIES = {
+    RPI_A_KEY: {
+        'name': 'Raspberry Pi A',
+        'cpu_profile': RPI_1_CPU_PROFILE,
+        'performance': RPI_A_SCORE
+    },
+    RPI_A_PLUS_KEY: {
+        'name': 'Raspberry Pi A+',
+        'cpu_profile': RPI_1_CPU_PROFILE,
+        'performance': RPI_A_PLUS_SCORE
+
+    },
+    RPI_B_BETA_KEY: {
+        'name': 'Raspberry Pi B (Beta)',
+        'cpu_profile': RPI_1_CPU_PROFILE,
+        'performance': RPI_B_SCORE
+
+    },
+    RPI_B_KEY: {
+        'name': 'Raspberry Pi B',
+        'cpu_profile': RPI_1_CPU_PROFILE,
+        'performance': RPI_B_SCORE
+
+    },
+    RPI_B_PLUS_KEY: {
+        'name': 'Raspberry Pi B+',
+        'cpu_profile': RPI_1_CPU_PROFILE,
+        'performance': RPI_B_PLUS_SCORE
+
+    },
+    RPI_ZERO_KEY: {
+        'name': 'Raspberry Pi Zero',
+        'cpu_profile': RPI_1_CPU_PROFILE,
+        'performance': RPI_ZERO_SCORE
+
+    },
+    RPI_COMPUTE_KEY: {
+        'name': 'Raspberry Pi Compute Module',
+        'cpu_profile': RPI_1_CPU_PROFILE,
+        'performance': RPI_COMPUTE_SCORE
+
+    },
+    RPI_2_B_KEY: {
+        'name': 'Raspberry Pi 2',
+        'cpu_profile': RPI_2_CPU_PROFILE,
+        'performance': RPI_2_B_SCORE
+    }
 }
+
+
+def get_board_property(board_key, prop):
+    board = BOARD_PROPERTIES.get(board_key)
+
+    if not board:
+        return
+
+    board_prop = board.get(prop)
+
+    if not board_prop:
+        return
+
+    return board_prop
 
 
 def detect_kano_keyboard():
@@ -48,23 +119,23 @@ def detect_kano_keyboard():
 
 
 def is_model_a(revision=None):
-    return get_rpi_model(revision) == 'RPI/A'
+    return get_rpi_model(revision) == RPI_A_KEY
 
 
 def is_model_b(revision=None):
-    return get_rpi_model(revision) == 'RPI/B'
+    return get_rpi_model(revision) == RPI_B_KEY
 
 
 def is_model_b_plus(revision=None):
-    return get_rpi_model(revision) == 'RPI/B+'
+    return get_rpi_model(revision) == RPI_B_PLUS_KEY
 
 
 def is_model_2_b(revision=None):
-    return get_rpi_model(revision) == 'RPI/2/B'
+    return get_rpi_model(revision) == RPI_2_B_KEY
 
 
 def is_model_zero(revision=None):
-    return get_rpi_model(revision) == 'RPI/Zero'
+    return get_rpi_model(revision) == RPI_ZERO_KEY
 
 
 def get_rpi_model(revision=None):
@@ -85,21 +156,21 @@ def get_rpi_model(revision=None):
                     revision = entry.split(':')[1]
 
         if revision == 'Beta':
-            model_name = 'RPI/B (Beta)'
+            model_name = RPI_B_BETA_KEY
         elif int(revision, 16) & 0x00ff in (0x2, 0x3, 0x4, 0x5, 0x6, 0xd, 0xe, 0xf):
-            model_name = 'RPI/B'
+            model_name = RPI_B_KEY
         elif int(revision, 16) & 0x00ff in (0x7, 0x8, 0x9):
-            model_name = 'RPI/A'
+            model_name = RPI_A_KEY
         elif int(revision, 16) & 0x00ff in (0x10, 0x13):
-            model_name = 'RPI/B+'
+            model_name = RPI_B_PLUS_KEY
         elif int(revision, 16) & 0x00ff == 0x11:
-            model_name = 'Compute Module'
+            model_name = RPI_COMPUTE_KEY
         elif int(revision, 16) & 0x00ff == 0x12:
-            model_name = 'RPI/A+'
+            model_name = RPI_A_PLUS_KEY
         elif int(revision, 16) & 0x00FFFFFF in (0x00A01041, 0x00A21041):
-            model_name = 'RPI/2/B'
+            model_name = RPI_2_B_KEY
         elif int(revision, 16) & 0x00FFFFFF == 0x00900092:
-            model_name = 'RPI/Zero'
+            model_name = RPI_ZERO_KEY
         else:
             model_name = 'unknown revision: {}'.format(revision)
 
@@ -151,13 +222,8 @@ def has_min_performance(score):
         rv (bool) - True if the hardware has a higher score than the given or if the
                     hardware could not be detected; and False otherwise
     """
-    rv = True
+
     model = get_rpi_model()
+    model_score = get_board_property(model, 'performance')
 
-    if model in PERFORMANCE_SCORES:
-        model_score = PERFORMANCE_SCORES[model]
-
-        if model_score < score:
-            rv = False
-
-    return rv
+    return not model_score or model_score >= score


### PR DESCRIPTION
Supply, in addition to the board performance, the human readable board
name and the profile to use for clocking.

@radujipa An extension of what you did to make some properties a little easier to access.

cc @convolu