### PR TITLE
Fix when Quality = ''

### DIFF
--- a/kano/network.py
+++ b/kano/network.py
@@ -221,8 +221,11 @@ class IWList():
         '''
 
         def sortNetworks(adict):
-            x, z = adict['quality'].split('/')
-            factor = int(x) / float(z)
+            if adict['quality'] != '':
+                x, z = adict['quality'].split('/')
+                factor = int(x) / float(z)
+            else:
+                factor = 0
             return factor
 
         def add_wnet(wlist, new_wnet):


### PR DESCRIPTION
Some APs are returning Quality values of single integers instead of x/100. I'm not sure why, but getCellQuality doesn't seem to recognize a single integer, and so Quality ends up being set to '', per the default value set in line 157.

Unfortunately, when sortNetworks then tries to figure out a sorting factor, it assumes there will be a slash, and we get the error: Unhandled exception 'need more than 1 value to unpack' at /usr/lib/python2.7/dist-packages/kano/network.py line 225

I couldn't figure out why getCellQuality isn't able to deal with a single integer Quality, but I was able to workaround these weird APs (luckily neither of them is mine) by setting factor to 0 if Quality = ''.