### PR TITLE
Fix for Quality/Signal level output variations

### DIFF
--- a/kano/network.py
+++ b/kano/network.py
@@ -131,7 +131,7 @@ class IWList():
                 return s.strip().split(":")[1]
 
             def getCellSignal(s):
-                s = s.split("Signal level=")[1]
+                s = re.split('Signal level(=|:)', s)[2]
                 return s.strip().split(" ")[0]
 
             def getCellNoise(s):
@@ -142,7 +142,7 @@ class IWList():
                     return 0
 
             def getCellQuality(s):
-                s = s.split("=")[1]
+                s = re.split('(=|:)', s)[2]
                 return s.strip().split(" ")[0]
 
             def getCellMAC(s):
@@ -177,7 +177,7 @@ class IWList():
                 if s.strip().startswith("Frequency:"):
                     cellData["Frequency"] = getCellFrequency(s)
                     cellData["Channel"] = getCellChannel(s)
-                if s.strip().startswith("Quality="):
+                if s.strip().startswith("Quality"):
                     cellData["Quality"] = getCellQuality(s)
                     cellData["Signal"] = getCellSignal(s)
                     cellData["Noise"] = getCellNoise(s)
@@ -233,8 +233,11 @@ class IWList():
         '''
 
         def sortNetworks(adict):
-            x, z = adict['quality'].split('/')
-            factor = int(x) / float(z)
+            if '/' in adict['quality']:
+                x, z = adict['quality'].split('/')
+                factor = int(x) / float(z)
+            else:
+                factor = int(adict['quality']) / 100
             return factor
 
         def add_wnet(wlist, new_wnet):


### PR DESCRIPTION
As mentioned in https://github.com/KanoComputing/kano-toolset/issues/198, the format of Quality and Signal level changes when iwlist cannot get a range for some Access Points (or perhaps it's related to the wireless driver). At any rate, I've observed a 2Wire/AT&T U-verse router showing:

`Quality:40  Signal level:0  Noise level:0`

The original parser only accounts for Quality/Signal level in this format:

`Quality=72/100  Signal level=65/100`

This change accommodates the possibility of for a colon in addition to an equals sign, and also can handle an integer value for Quality as opposed to a fraction.