### PR TITLE
Add kano-dispmanx-launch

### DIFF
--- a/bin/kano-dispmanx-launch
+++ b/bin/kano-dispmanx-launch
@@ -11,6 +11,8 @@
 # These are queued to run next.
 #
 # Usage: kano-dispmanx-launch cmd
+# Example: kano-dispmanx-launch "/usr/bin/love-0.10 /usr/bin/kanoOverworld.love"
+
 import subprocess
 import sys
 

--- a/bin/kano-dispmanx-launch
+++ b/bin/kano-dispmanx-launch
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# kano-dispmanx-launch
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# Allow dispmanx apps to launch each other without overlapping.
+# We run the first command, then scan its output for lines like
+# TO_LAUNCH:cmd
+# These are queued to run next.
+#
+# Usage: kano-dispmanx-launch cmd
+import subprocess
+import sys
+
+# Queue ofcommands to launch
+to_launch = [sys.argv[1]]
+
+launch_prefix = "TO_LAUNCH:"
+
+while to_launch:
+   cmd = to_launch.pop(0)
+   out = subprocess.check_output(cmd, shell=True).split('\n')
+   for line in out:
+      print line # copy to stdout
+      if line.startswith(launch_prefix):
+         cmd = line[len(launch_prefix):]
+         to_launch.append(cmd)


### PR DESCRIPTION
Add 'kano-dispmanx-launch' command for launching dispmanx apps which need to launch other dispmanx apps with no overlap.
This is to address https://github.com/KanoComputing/kano-overworld/issues/13

It expects 'TO_LAUNCH:' commands in stdout of the apps it launches. it copies stdout to its own stdout, but currently it does so only after the app has finished, reducing the utility of stdout for debugging. This could be fixed or we could use stderr.

@alex5imon @radujipa 
