### PR TITLE
Lazy imports

### DIFF
--- a/kano/_logging.py
+++ b/kano/_logging.py
@@ -1,0 +1,356 @@
+# kano.logging
+#
+# Copyright (C) 2014 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+
+'''
+This module provides the core Kano Logging functionality
+'''
+
+import os
+import sys
+import re
+import pwd
+import grp
+import json
+import time
+import yaml
+from kano.colours import decorate_string_only_terminal, decorate_with_preset
+from kano.utils import get_home_by_username
+
+LOG_ENV = "LOG_LEVEL"
+OUTPUT_ENV = "OUTPUT_LEVEL"
+FORCE_FLUSH_ENV = "KLOG_FORCE_FLUSH"
+SYSTEM_LOGS_DIR = "/var/log/kano/"
+
+# The length to which will the log files be cut to when cleaned up
+TAIL_LENGTH = 500
+
+# get_user_unsudoed() cannot be used due to a circular dependency
+is_sudoed = 'SUDO_USER' in os.environ
+usr = os.getenv("SUDO_USER") if is_sudoed else pwd.getpwuid(os.getuid())[0]
+
+try:
+    home_folder = get_home_by_username(usr)
+except KeyError:  # user doesn't exist
+    if is_sudoed:
+        # something weird happened with sudo
+        # fall back to the root user
+        usr = "root"
+        home_folder = "/root/"
+    else:
+        raise
+
+USER_LOGS_DIR = os.path.join(home_folder, '.kano-logs')
+
+CONF_FILE = "/etc/kano-logs.conf"
+
+LEVELS = {
+    "none": 0,
+    "error": 1,
+    "warning": 2,
+    "info": 3,
+    "debug": 4
+}
+
+
+def normalise_level(level):
+    '''
+    Normalise the input string, i.e.
+    convert it into lowercase and see if it matches with
+    the specified levels held in the dict LEVELS.
+    It will try to match the input to the first n chars
+    of the dict. ex 'd', 'de' is turned into debug.
+    '''
+
+    if level is None:
+        return "none"
+
+    level = level.lower()
+    for l in LEVELS.iterkeys():
+        if level == l[0:len(level)]:
+            return l
+
+    return "none"
+
+
+class Logger:
+    def __init__(self):
+        self._log_file = None
+        self._app_name = None
+        self._force_flush = False
+        self._pid = os.getpid()
+
+        self._cached_log_level = None
+        self._cached_output_level = None
+        self._load_conf()
+
+        log = os.getenv(LOG_ENV)
+        if log is not None:
+            self._cached_log_level = normalise_level(log)
+
+        output = os.getenv(OUTPUT_ENV)
+        if output is not None:
+            self._cached_output_level = normalise_level(output)
+
+        force_flush = os.getenv(FORCE_FLUSH_ENV)
+        if force_flush is not None:
+            self._force_flush = True
+
+    def _load_conf(self):
+        conf = None
+        if os.path.exists(CONF_FILE):
+            with open(CONF_FILE, "r") as f:
+                conf = yaml.load(f)
+
+        if conf is None:
+            conf = {}
+
+        if "log_level" not in conf:
+            conf["log_level"] = "none"
+
+        if "output_level" not in conf:
+            conf["output_level"] = "none"
+
+        if self._cached_log_level is None:
+            self._cached_log_level = normalise_level(conf["log_level"])
+
+        if self._cached_output_level is None:
+            self._cached_output_level = normalise_level(conf["output_level"])
+
+    def get_log_level(self):
+        if self._cached_log_level is None:
+            self._load_conf()
+
+        return self._cached_log_level
+
+    def get_output_level(self):
+        if self._cached_output_level is None:
+            self._load_conf()
+
+        return self._cached_output_level
+
+    def force_log_level(self, level):
+        normalised = normalise_level(level)
+        if not self._cached_log_level or \
+           LEVELS[self._cached_log_level] < LEVELS[normalised]:
+            self._cached_log_level = normalised
+
+    def force_debug_level(self, level):
+        normalised = normalise_level(level)
+        if not self._cached_output_level or \
+           LEVELS[self._cached_output_level] < LEVELS[normalised]:
+            self._cached_output_level = normalised
+
+    def set_app_name(self, name):
+        self._app_name = os.path.basename(name.strip()).lower().replace(" ", "_")
+        if self._log_file is not None:
+            self._log_file.close()
+            self._log_file = None
+
+    def set_force_flush(self):
+        self._force_flush = True
+
+    def unset_force_flush(self):
+        self._force_flush = False
+
+    def write(self, msg, force_flush=False, **kwargs):
+        lname = "info"
+        if "level" in kwargs:
+            lname = normalise_level(kwargs["level"])
+
+        level = LEVELS[lname]
+        sys_log_level = LEVELS[self.get_log_level()]
+        sys_output_level = LEVELS[self.get_output_level()]
+
+        if level > 0 and (level <= sys_log_level or level <= sys_output_level):
+            if self._app_name is None:
+                self.set_app_name(sys.argv[0])
+
+            lines = str(msg).strip().split("\n")
+
+            log = {}
+            log["pid"] = self._pid
+            log.update(kwargs)
+            log["level"] = lname
+
+            # if an exception object was passed in, add it to the log fields
+            tbk = None
+            if 'exception' in kwargs:
+                import traceback
+                tbk = traceback.format_exc()
+                log['exception'] = str(kwargs['exception'])
+                log['traceback'] = tbk
+
+            for line in lines:
+                log["time"] = time.time()
+                log["message"] = line
+
+                if level <= sys_log_level:
+                    if self._log_file is None:
+                        self._init_log_file()
+                    self._log_file.write("{}\n".format(json.dumps(log)))
+
+                    if self._force_flush or force_flush:
+                        self.sync()
+
+                if level <= sys_output_level:
+                    output_line = "{}[{}] {} {}\n".format(
+                        self._app_name,
+                        decorate_string_only_terminal(self._pid, "yellow"),
+                        decorate_with_preset(log["level"], log["level"], True),
+                        log["message"]
+                    )
+                    sys.stderr.write(output_line)
+
+    def sync(self):
+        self.flush()
+
+    def error(self, msg, **kwargs):
+        kwargs["level"] = "error"
+        self.write(msg, **kwargs)
+
+    def debug(self, msg, **kwargs):
+        kwargs["level"] = "debug"
+        self.write(msg, **kwargs)
+
+    def warn(self, msg, **kwargs):
+        kwargs["level"] = "warn"
+        self.write(msg, **kwargs)
+
+    def info(self, msg, **kwargs):
+        kwargs["level"] = "info"
+        self.write(msg, **kwargs)
+
+    def flush(self):
+        if self._log_file and not self._log_file.closed:
+            self._log_file.flush()
+
+        sys.stderr.flush()
+
+    def _init_log_file(self):
+        if self._log_file is not None:
+            self._log_file.close()
+
+        if os.getuid() == 0 and not is_sudoed:
+            logs_dir = SYSTEM_LOGS_DIR
+        else:
+            logs_dir = USER_LOGS_DIR
+
+        if not os.path.exists(logs_dir):
+            os.makedirs(logs_dir)
+
+            # Fix permissions in case we need to create the dir with sudo
+            if is_sudoed:
+                uid = pwd.getpwnam(usr).pw_uid
+                gid = grp.getgrnam(usr).gr_gid
+                os.chown(logs_dir, uid, gid)
+
+        log_fn = "{}/{}.log".format(logs_dir, self._app_name)
+
+        # Fix permissions in case we need to create the file with sudo
+        if not os.path.isfile(log_fn) and is_sudoed:
+            # touch
+            with open(log_fn, 'a'):
+                pass
+
+            uid = pwd.getpwnam(usr).pw_uid
+            gid = grp.getgrnam(usr).gr_gid
+            os.chown(log_fn, uid, gid)
+
+        self._log_file = open("{}/{}.log".format(logs_dir, self._app_name), "a")
+
+logger = Logger()
+
+
+def set_system_log_level(lvl):
+    _set_conf_var("log_level", lvl)
+
+
+def set_system_output_level(lvl):
+    _set_conf_var("output_level", lvl)
+
+
+def _set_conf_var(var, value):
+    conf = None
+    if os.path.isfile(CONF_FILE):
+        with open(CONF_FILE, "r") as f:
+            conf = yaml.load(f)
+    if conf is None:
+        conf = {}
+
+    conf[var] = normalise_level(str(value))
+
+    with open(CONF_FILE, "w") as f:
+        f.write(yaml.dump(conf, default_flow_style=False))
+
+
+def read_logs(app=None):
+    data = {}
+    for d in [USER_LOGS_DIR, SYSTEM_LOGS_DIR]:
+        if os.path.isdir(d):
+            for log in os.listdir(d):
+                if app is None or re.match("^{}\.log".format(app), log):
+                    log_path = os.path.join(d, log)
+                    with open(log_path, "r") as f:
+                        data[log_path] = []
+                        for line in f.readlines():
+                            try:
+                                data[log_path].append(json.loads(line))
+                            except:
+                                # unable to read the line, skip it
+                                pass
+
+    return data
+
+
+def cleanup(app=None, line_limit=TAIL_LENGTH):
+    dirs = [USER_LOGS_DIR]
+    if os.getuid() == 0:
+        dirs.append(SYSTEM_LOGS_DIR)
+
+    for d in dirs:
+        if os.path.isdir(d):
+            for log in os.listdir(d):
+                if app is None or re.match("^{}\.log".format(app), log):
+                    log_path = os.path.join(d, log)
+                    try:
+                        __tail_log_file(log_path, line_limit)
+                    except IOError:
+                        pass
+
+
+def __tail_log_file(file_path, length):
+    data = None
+    with open(file_path, "r") as f:
+        data = f.readlines()
+
+    if len(data) <= length:
+        return
+
+    with open(file_path, "w") as f:
+        f.write("".join(data[(len(data) - length):]))
+
+
+# set exception hook to log exceptions
+
+def log_excepthook(exc_class, exc_value, tb):
+    import traceback
+
+    tb_txt = ''.join(traceback.format_tb(tb))
+    try:
+        (filename, number, function, line_text) = traceback.extract_tb(tb)[-1]
+        exc_txt = "{} line {} function {} [{}]".format(
+            filename, number, function, line_text)
+    except:
+        exc_txt = ""
+
+    logger.error("Unhandled exception '{}' at {}"
+                 .format(exc_value, exc_txt),
+                 traceback=tb_txt,
+                 exc_class=str(exc_class),
+                 exc_value=str(exc_value))
+    sys.__excepthook__(exc_class, exc_value, tb)
+
+sys.excepthook = log_excepthook

--- a/kano/logging.py
+++ b/kano/logging.py
@@ -6,337 +6,52 @@
 
 '''
 This module provides the core Kano Logging functionality
+However it is actually a lazy loader for kano._logging
 '''
 
-import os
 import sys
-import re
-import pwd
-import grp
-import json
-import time
-import yaml
-from kano.colours import decorate_string_only_terminal, decorate_with_preset
-from kano.utils import get_home_by_username
 
-LOG_ENV = "LOG_LEVEL"
-OUTPUT_ENV = "OUTPUT_LEVEL"
-FORCE_FLUSH_ENV = "KLOG_FORCE_FLUSH"
-SYSTEM_LOGS_DIR = "/var/log/kano/"
+# The way this module works is that the 'kano.logging' entry in sys.modules gets substituted twice:
+# First, with the loader class below
+# When an attribute on that class is accessed, it gets substituted a second time.
 
-# The length to which will the log files be cut to when cleaned up
-TAIL_LENGTH = 500
+class lazy_logger:
+    def __getattr__(self, name):
+        import kano._logging
+        return getattr(kano._logging.logger, name)
 
-# get_user_unsudoed() cannot be used due to a circular dependency
-is_sudoed = 'SUDO_USER' in os.environ
-usr = os.getenv("SUDO_USER") if is_sudoed else pwd.getpwuid(os.getuid())[0]
 
-try:
-    home_folder = get_home_by_username(usr)
-except KeyError:  # user doesn't exist
-    if is_sudoed:
-        # something weird happened with sudo
-        # fall back to the root user
-        usr = "root"
-        home_folder = "/root/"
-    else:
-        raise
+class loader:
+    ll = lazy_logger
 
-USER_LOGS_DIR = os.path.join(home_folder, '.kano-logs')
+    def __init__(self, old_mod):
+        self.old_mod = old_mod
 
-CONF_FILE = "/etc/kano-logs.conf"
+    def __getattr__(self, name):
+        # avoid importing the module just to make a logger object
+        if name == '__path__':
+            return getattr(self.old_mod, name)
 
-LEVELS = {
-    "none": 0,
-    "error": 1,
-    "warning": 2,
-    "info": 3,
-    "debug": 4
-}
+        if name == 'logger':
+            return self.ll()
 
+        # load the real module
+        # at this point we have substituted the module once,
+        # so we need to import sys again
+        import sys
+        import kano._logging  
 
-def normalise_level(level):
-    '''
-    Normalise the input string, i.e.
-    convert it into lowercase and see if it matches with
-    the specified levels held in the dict LEVELS.
-    It will try to match the input to the first n chars
-    of the dict. ex 'd', 'de' is turned into debug.
-    '''
+        lm = sys.modules['kano._logging']
+        sys.modules[__name__] = lm
+        return getattr(lm, name)
 
-    if level is None:
-        return "none"
-
-    level = level.lower()
-    for l in LEVELS.iterkeys():
-        if level == l[0:len(level)]:
-            return l
-
-    return "none"
-
-
-class Logger:
-    def __init__(self):
-        self._log_file = None
-        self._app_name = None
-        self._force_flush = False
-        self._pid = os.getpid()
-
-        self._cached_log_level = None
-        self._cached_output_level = None
-        self._load_conf()
-
-        log = os.getenv(LOG_ENV)
-        if log is not None:
-            self._cached_log_level = normalise_level(log)
-
-        output = os.getenv(OUTPUT_ENV)
-        if output is not None:
-            self._cached_output_level = normalise_level(output)
-
-        force_flush = os.getenv(FORCE_FLUSH_ENV)
-        if force_flush is not None:
-            self._force_flush = True
-
-    def _load_conf(self):
-        conf = None
-        if os.path.exists(CONF_FILE):
-            with open(CONF_FILE, "r") as f:
-                conf = yaml.load(f)
-
-        if conf is None:
-            conf = {}
-
-        if "log_level" not in conf:
-            conf["log_level"] = "none"
-
-        if "output_level" not in conf:
-            conf["output_level"] = "none"
-
-        if self._cached_log_level is None:
-            self._cached_log_level = normalise_level(conf["log_level"])
-
-        if self._cached_output_level is None:
-            self._cached_output_level = normalise_level(conf["output_level"])
-
-    def get_log_level(self):
-        if self._cached_log_level is None:
-            self._load_conf()
-
-        return self._cached_log_level
-
-    def get_output_level(self):
-        if self._cached_output_level is None:
-            self._load_conf()
-
-        return self._cached_output_level
-
-    def force_log_level(self, level):
-        normalised = normalise_level(level)
-        if not self._cached_log_level or \
-           LEVELS[self._cached_log_level] < LEVELS[normalised]:
-            self._cached_log_level = normalised
-
-    def force_debug_level(self, level):
-        normalised = normalise_level(level)
-        if not self._cached_output_level or \
-           LEVELS[self._cached_output_level] < LEVELS[normalised]:
-            self._cached_output_level = normalised
-
-    def set_app_name(self, name):
-        self._app_name = os.path.basename(name.strip()).lower().replace(" ", "_")
-        if self._log_file is not None:
-            self._log_file.close()
-            self._log_file = None
-
-    def set_force_flush(self):
-        self._force_flush = True
-
-    def unset_force_flush(self):
-        self._force_flush = False
-
-    def write(self, msg, force_flush=False, **kwargs):
-        lname = "info"
-        if "level" in kwargs:
-            lname = normalise_level(kwargs["level"])
-
-        level = LEVELS[lname]
-        sys_log_level = LEVELS[self.get_log_level()]
-        sys_output_level = LEVELS[self.get_output_level()]
-
-        if level > 0 and (level <= sys_log_level or level <= sys_output_level):
-            if self._app_name is None:
-                self.set_app_name(sys.argv[0])
-
-            lines = str(msg).strip().split("\n")
-
-            log = {}
-            log["pid"] = self._pid
-            log.update(kwargs)
-            log["level"] = lname
-
-            # if an exception object was passed in, add it to the log fields
-            tbk = None
-            if 'exception' in kwargs:
-                import traceback
-                tbk = traceback.format_exc()
-                log['exception'] = str(kwargs['exception'])
-                log['traceback'] = tbk
-
-            for line in lines:
-                log["time"] = time.time()
-                log["message"] = line
-
-                if level <= sys_log_level:
-                    if self._log_file is None:
-                        self._init_log_file()
-                    self._log_file.write("{}\n".format(json.dumps(log)))
-
-                    if self._force_flush or force_flush:
-                        self.sync()
-
-                if level <= sys_output_level:
-                    output_line = "{}[{}] {} {}\n".format(
-                        self._app_name,
-                        decorate_string_only_terminal(self._pid, "yellow"),
-                        decorate_with_preset(log["level"], log["level"], True),
-                        log["message"]
-                    )
-                    sys.stderr.write(output_line)
-
-    def sync(self):
-        self.flush()
-
-    def error(self, msg, **kwargs):
-        kwargs["level"] = "error"
-        self.write(msg, **kwargs)
-
-    def debug(self, msg, **kwargs):
-        kwargs["level"] = "debug"
-        self.write(msg, **kwargs)
-
-    def warn(self, msg, **kwargs):
-        kwargs["level"] = "warn"
-        self.write(msg, **kwargs)
-
-    def info(self, msg, **kwargs):
-        kwargs["level"] = "info"
-        self.write(msg, **kwargs)
-
-    def flush(self):
-        if self._log_file and not self._log_file.closed:
-            self._log_file.flush()
-
-        sys.stderr.flush()
-
-    def _init_log_file(self):
-        if self._log_file is not None:
-            self._log_file.close()
-
-        if os.getuid() == 0 and not is_sudoed:
-            logs_dir = SYSTEM_LOGS_DIR
-        else:
-            logs_dir = USER_LOGS_DIR
-
-        if not os.path.exists(logs_dir):
-            os.makedirs(logs_dir)
-
-            # Fix permissions in case we need to create the dir with sudo
-            if is_sudoed:
-                uid = pwd.getpwnam(usr).pw_uid
-                gid = grp.getgrnam(usr).gr_gid
-                os.chown(logs_dir, uid, gid)
-
-        log_fn = "{}/{}.log".format(logs_dir, self._app_name)
-
-        # Fix permissions in case we need to create the file with sudo
-        if not os.path.isfile(log_fn) and is_sudoed:
-            # touch
-            with open(log_fn, 'a'):
-                pass
-
-            uid = pwd.getpwnam(usr).pw_uid
-            gid = grp.getgrnam(usr).gr_gid
-            os.chown(log_fn, uid, gid)
-
-        self._log_file = open("{}/{}.log".format(logs_dir, self._app_name), "a")
-
-logger = Logger()
-
-
-def set_system_log_level(lvl):
-    _set_conf_var("log_level", lvl)
-
-
-def set_system_output_level(lvl):
-    _set_conf_var("output_level", lvl)
-
-
-def _set_conf_var(var, value):
-    conf = None
-    if os.path.isfile(CONF_FILE):
-        with open(CONF_FILE, "r") as f:
-            conf = yaml.load(f)
-    if conf is None:
-        conf = {}
-
-    conf[var] = normalise_level(str(value))
-
-    with open(CONF_FILE, "w") as f:
-        f.write(yaml.dump(conf, default_flow_style=False))
-
-
-def read_logs(app=None):
-    data = {}
-    for d in [USER_LOGS_DIR, SYSTEM_LOGS_DIR]:
-        if os.path.isdir(d):
-            for log in os.listdir(d):
-                if app is None or re.match("^{}\.log".format(app), log):
-                    log_path = os.path.join(d, log)
-                    with open(log_path, "r") as f:
-                        data[log_path] = []
-                        for line in f.readlines():
-                            try:
-                                data[log_path].append(json.loads(line))
-                            except:
-                                # unable to read the line, skip it
-                                pass
-
-    return data
-
-
-def cleanup(app=None, line_limit=TAIL_LENGTH):
-    dirs = [USER_LOGS_DIR]
-    if os.getuid() == 0:
-        dirs.append(SYSTEM_LOGS_DIR)
-
-    for d in dirs:
-        if os.path.isdir(d):
-            for log in os.listdir(d):
-                if app is None or re.match("^{}\.log".format(app), log):
-                    log_path = os.path.join(d, log)
-                    try:
-                        __tail_log_file(log_path, line_limit)
-                    except IOError:
-                        pass
-
-
-def __tail_log_file(file_path, length):
-    data = None
-    with open(file_path, "r") as f:
-        data = f.readlines()
-
-    if len(data) <= length:
-        return
-
-    with open(file_path, "w") as f:
-        f.write("".join(data[(len(data) - length):]))
-
-
-# set exception hook to log exceptions
 
 def log_excepthook(exc_class, exc_value, tb):
+    # at this point we have substituted the module once,
+    # so we need to import all modules again
     import traceback
+    import kano.logging # Don't think about this one too hard...
+    import sys
 
     tb_txt = ''.join(traceback.format_tb(tb))
     try:
@@ -346,7 +61,7 @@ def log_excepthook(exc_class, exc_value, tb):
     except:
         exc_txt = ""
 
-    logger.error("Unhandled exception '{}' at {}"
+    kano.logging.logger.error("Unhandled exception '{}' at {} (see logfile for full trace)"
                  .format(exc_value, exc_txt),
                  traceback=tb_txt,
                  exc_class=str(exc_class),
@@ -354,3 +69,6 @@ def log_excepthook(exc_class, exc_value, tb):
     sys.__excepthook__(exc_class, exc_value, tb)
 
 sys.excepthook = log_excepthook
+
+# substitute the lazy loader module
+sys.modules[__name__] = loader(sys.modules[__name__])

--- a/kano/utils/__init__.py
+++ b/kano/utils/__init__.py
@@ -9,46 +9,141 @@
 __author__ = 'Kano Computing Ltd.'
 __email__ = 'dev@kano.me'
 
+import sys
 
-from kano.utils.audio import \
-    play_sound, percent_to_millibel, get_volume
+def ku_audio(name):
+    import kano.utils.audio
+    return getattr(kano.utils.audio, name)
 
-from kano.utils.disk import \
-    get_free_space, get_partition_info
+def ku_file_operations(name):
+    import kano.utils.file_operations
+    return getattr(kano.utils.file_operations, name)
 
-from kano.utils.file_operations import \
-    read_file_contents, write_file_contents, read_file_contents_as_lines, \
-    delete_dir, delete_file, ensure_dir, list_dir, chown_path, read_json, \
-    write_json, open_locked, sed
+def ku_disk(name):
+    import kano.utils.disk
+    return getattr(kano.utils.disk, name)
 
-from kano.utils.gui import \
-    is_gui, zenity_show_progress
+def ku_gui(name):
+    import kano.utils.gui
+    return getattr(kano.utils.gui, name)
 
-from kano.utils.hardware import \
-    detect_kano_keyboard, is_model_a, is_model_b, is_model_b_plus, is_model_zero, \
-    is_model_2_b, get_rpi_model, is_monitor, get_mac_address, get_cpu_id, \
-    has_min_performance
+def ku_hardware(name):
+    import kano.utils.hardware
+    return getattr(kano.utils.hardware, name)
 
-from kano.utils.hardware import \
-    RPI_A_SCORE, RPI_A_PLUS_SCORE, RPI_B_SCORE, RPI_B_PLUS_SCORE, \
-    RPI_ZERO_SCORE, RPI_COMPUTE_SCORE, RPI_2_B_SCORE
+def ku_http_requests(name):
+    import kano.utils.http_requests
+    return getattr(kano.utils.http_requests, name)
 
-from kano.utils.http_requests import \
-    proxies, download_url, requests_get_json, debug_requests
+def ku_misc(name):
+    import kano.utils.misc
+    return getattr(kano.utils.misc, name)
 
-from kano.utils.misc import \
-    get_date_now, is_number, uniqify_list, is_installed
+def ku_processes(name):
+    import kano.utils.processes
+    return getattr(kano.utils.processes, name)
 
-from kano.utils.processes import \
-    kill_child_processes, is_running, get_program_name, pkill
+def ku_shell(name):
+    import kano.utils.shell
+    return getattr(kano.utils.shell, name)
 
-from kano.utils.shell import \
-    run_cmd, run_cmd_log, run_bg, run_term_on_error, run_print_output_error, \
-    restore_signals
+def ku_system(name):
+    import kano.utils.system
+    return getattr(kano.utils.system, name)
 
-from kano.utils.system import \
-    is_jessie, is_systemd
+def ku_user(name):
+    import kano.utils.user
+    return getattr(kano.utils.user, name)
+        
+functable = {
+    'play_sound': ku_audio,
+    'percent_to_millibel': ku_audio,
+    'get_volume': ku_audio,
 
-from kano.utils.user import \
-    get_user_getpass, get_user, get_user_unsudoed, get_home, \
-    get_home_by_username, get_all_home_folders, enforce_root
+    'read_file_contents': ku_file_operations,
+    'write_file_contents': ku_file_operations,
+    'read_file_contents_as_lines': ku_file_operations,
+    'delete_dir': ku_file_operations,
+    'delete_file': ku_file_operations,
+    'ensure_dir': ku_file_operations,
+    'list_dir': ku_file_operations,
+    'chown_path': ku_file_operations,
+    'read_json': ku_file_operations,
+    'write_json': ku_file_operations,
+    'open_locked': ku_file_operations,
+    'sed': ku_file_operations,
+
+    'get_free_space': ku_disk,
+    'get_partition_info': ku_disk,
+
+    'is_gui': ku_gui,
+    'zenity_show_progress': ku_gui,
+
+    'detect_kano_keyboard': ku_hardware,
+    'is_model_a': ku_hardware,
+    'is_model_b': ku_hardware,
+    'is_model_b_plus': ku_hardware,
+    'is_model_zero': ku_hardware,
+    'is_model_2_b': ku_hardware,
+    'get_rpi_model': ku_hardware,
+    'is_monitor': ku_hardware,
+    'get_mac_address': ku_hardware,
+    'get_cpu_id': ku_hardware,
+    'has_min_performance': ku_hardware,
+
+    'RPI_A_SCORE': ku_hardware,
+    'RPI_A_PLUS_SCORE': ku_hardware,
+    'RPI_B_SCORE': ku_hardware,
+    'RPI_B_PLUS_SCORE': ku_hardware,
+    'RPI_ZERO_SCORE': ku_hardware,
+    'RPI_COMPUTE_SCORE': ku_hardware,
+    'RPI_2_B_SCORE': ku_hardware,
+
+    'proxies': ku_http_requests,
+    'download_url': ku_http_requests,
+    'requests_get_json': ku_http_requests,
+    'debug_requests': ku_http_requests,
+    'get_date_now': ku_misc,
+    'is_number': ku_misc,
+    'uniqify_list': ku_misc,
+    'is_installed': ku_misc,
+
+    'kill_child_processes': ku_processes,
+    'is_running': ku_processes,
+    'get_program_name': ku_processes,
+    'pkill': ku_processes,
+
+    'run_cmd': ku_shell,
+    'run_cmd_log': ku_shell,
+    'run_bg': ku_shell,
+    'run_term_on_error': ku_shell,
+    'run_print_output_error': ku_shell,
+    'restore_signals': ku_shell,
+
+    'is_jessie': ku_system,
+    'is_systemd': ku_system,
+
+
+    'get_user_getpass': ku_user,
+    'get_user': ku_user,
+    'get_user_unsudoed': ku_user,
+    'get_home': ku_user,
+    'get_home_by_username': ku_user,
+    'get_all_home_folders': ku_user,
+    'enforce_root': ku_user
+
+}
+
+# lazy loader: only import utils module when actually used
+class loader:
+    def __init__(self, oldmodule):
+        self.oldmodule = oldmodule
+
+    def __getattr__(self, name):
+        if name in functable:
+            return functable[name](name)
+        else:
+            return getattr(self.oldmodule, name)
+
+
+sys.modules[__name__] = loader(sys.modules[__name__])


### PR DESCRIPTION
This might be somewhat controversial.

I want to reduce the cost of running `kano-settings-cli get overscan`. This PR reduces the cost of importing things from kano.utils and kano.logging. It gets it in total from 0.7s to 0.2s (along with https://github.com/KanoComputing/kano-settings/issues/372). However it does make it rather more complicated. Opinions @alex5imon @radujipa @tombettany @skarbat ?
