### PR TITLE
Add __init__.py so the overnight tests will run these tests.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+#
+# __init__.py
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+__author__ = 'Kano Computing Ltd.'
+__email__ = 'dev@kano.me'


### PR DESCRIPTION
@skarbat @tombettany 
kano-toolset has some tests but these are not running overnoght because there is no `__init__.py`. 
Is there a reason why these tests should not run? 