### PR TITLE
Set user language of WebKit instance

### DIFF
--- a/kano/webapp.py
+++ b/kano/webapp.py
@@ -94,6 +94,9 @@ class WebApp(object):
         view.connect('close-web-view', self._close)
         view.connect('onload-event', self._onload)
 
+        language = os.getenv('LANG').replace('_', '-')
+        view.execute_script("window.navigator.userLanguage = '%s'" % language)
+
         if self._inspector:
             view.get_settings().set_property("enable-developer-extras", True)
 


### PR DESCRIPTION
This small modification is needed for localization, to allow applications to be displayed according to the user-defined language in Kano (see make-art Japanese translation).