### PR TITLE
Splash tool accepts parameters on the shebang

### DIFF
--- a/kano-splash/README.md
+++ b/kano-splash/README.md
@@ -20,15 +20,25 @@ to
 #!/usr/bin/kano-splash /usr/share/kano-foo/splash/png /usr/bin/env python 
 ```
 
-The app mush then call `system("kano-stop-splash")` to stop the splash (or wait for it to time out at 15 seconds). 
+The app mush then call `system("kano-stop-splash")` to stop the splash (or wait for it to time out at 15 seconds).
 
-Alternatively, the app can call
+Parameters can also be passed on the shebang with the ampersand delimiter, for example:
+
+```
+#!/usr/bin/kano-splash /usr/share/kano-foo/splash/png&t=60&b=0xffff /usr/bin/env python 
+```
+
+Would set the timeout to 60 seconds and show the splash image on a white background.
+
+Alternatively, the app can call:
 
 ```
  $ kano-start-splash -b <alpha> -t  <timeout> <splashfile>
 ```
 
-It must then save the PID and start time so that kano-stop-splash can determine which process to signal.
+Which is a symbolic link to `kano-splash`.
+
+It must then save the PID and start time so that `kano-stop-splash` can determine which process to signal.
 This is how to do that in bash:
 
 ```

--- a/kano-splash/kano-splash.c
+++ b/kano-splash/kano-splash.c
@@ -56,9 +56,11 @@
 void usage(void)
 {
   fprintf(stderr, "Usage: kano-splash-start [-b <RGBA>] [ -t <timeout> ] <file.png>\n");
-  fprintf(stderr, "    -b - set background colour 16 bit RGBA\n");
+  fprintf(stderr, "    -b - set background colour 16 bit RGBA, in 0x1234 notation\n");
   fprintf(stderr, "    -t - timeout in seconds\n");
-  fprintf(stderr, "         e.g. 0x000F is opaque black\n");
+  fprintf(stderr, "         e.g. background 0x000F is opaque black\n");
+  fprintf(stderr, "    Parameters in shebang are passed with the ampersand delimiter, e.g.\n");
+  fprintf(stderr, "    #!/usr/bin/kano-splash /path/my/image.png&t=5&b=0x00ff /bin/bash\n");
 
   exit(EXIT_FAILURE);
 }
@@ -245,9 +247,11 @@ int main(int argc, char *argv[])
     is_interp=strcmp(binary,"kano-splash")==0;
       
     if(!is_interp){
+
+        /* we are called from the command line */
         int opt=0;
-        
-        while ((opt = getopt(argc, argv, "b:t:")) != -1)
+
+        while ((opt = getopt(argc, argv, "b:t:h?")) != -1)
         {
             switch(opt)
             {
@@ -268,6 +272,7 @@ int main(int argc, char *argv[])
             }
         }
         file=argv[optind];
+
         //---------------------------------------------------------------------
    
         if (optind >= argc)
@@ -276,6 +281,8 @@ int main(int argc, char *argv[])
         }
     }
     else{
+
+        /* we are called from a shebang */
 
         // Parse command arguments
         // As we are acting as an 'interpreter' arguments are as follows:
@@ -299,12 +306,33 @@ int main(int argc, char *argv[])
           fprintf(stderr,"Insufficient arguments\n");
           exit(1);
         }
-    
+
+        /* find the image filename in the shebang */
         file=strsep(&argv[1]," ");
-    
         if(!file) {
           fprintf(stderr,"filename is NULL \n");      
 	  exit(1);
+        }
+        else {
+
+          /* try to find additional arguments in a custom shebang syntax */
+          /* example: #!/usr/bin/kano-splash /my/path/file.png&t=30&b=255 /bin/bash */
+          char *token=strtok(file, "&");
+
+          // if we have arguments, isolate the filename, then start parsing.
+          file=(token ? token : file);
+
+          while (token) {
+
+              if (!strncmp(token, "t=", 2)) {
+                  timeout = strtol(&token[2], NULL, 10);
+              }
+              else if (!strncmp(token, "b=", 2)) {
+                  background = strtol(&token[2], NULL, 16);
+              }
+
+              token=strtok(NULL, "&");
+          }
         }
     
         real_interp=strsep(&argv[1]," ");
@@ -318,6 +346,7 @@ int main(int argc, char *argv[])
           argv++;
           argc--;
         }
+
         // save back to argv for exec
         argv[0]=real_interp;
 


### PR DESCRIPTION
 * Special syntax allows for specifying timeout and background
 * Added usage documentation in the readme
 * Tested on the pi and works well

@Ealdwulf 

Addresses ticket: https://github.com/KanoComputing/os-dashboard/issues/171
