### PR TITLE
New function set to retrieve Kano version information

### DIFF
--- a/kano/utils/system.py
+++ b/kano/utils/system.py
@@ -44,6 +44,8 @@ def is_systemd():
 def get_kano_version_stamp():
     '''
     Returns the raw string from the version stamp file
+    Kanux version stamps come in this form:
+       " Sat Sep  3 03:18:24 BST 2016 Kanux-Beta-v3.5.0-jessie"
     '''
     with open(kanux_stamp_file, 'r') as f:
         return f.read().strip(' \n')
@@ -54,6 +56,7 @@ def get_kano_version_date():
     Returns the date this version was built
     '''
     try:
+        # FIXME: This is a little obscure
         return get_kano_version_stamp().split('-')[0].strip('Kanux')
     except:
         return 'n/a'

--- a/kano/utils/system.py
+++ b/kano/utils/system.py
@@ -8,6 +8,8 @@
 
 import os
 
+kanux_stamp_file='/boot/kanux_stamp'
+
 
 def is_jessie():
     '''
@@ -37,3 +39,47 @@ def is_systemd():
         return os.readlink('/sbin/init') == '/lib/systemd/systemd'
     except Exception:
         return False
+
+
+def get_kano_version_stamp():
+    '''
+    Returns the raw string from the version stamp file
+    '''
+    with open(kanux_stamp_file, 'r') as f:
+        return f.read().strip(' \n')
+
+
+def get_kano_version_date():
+    '''
+    Returns the date this version was built
+    '''
+    try:
+        return get_kano_version_stamp().split('-')[0].strip('Kanux')
+    except:
+        return 'n/a'
+
+
+def get_kano_version_number():
+    '''
+    returns the Kano OS version number
+    '''
+    stamp=get_kano_version_stamp().split('-')
+    for item in stamp:
+        if item.startswith('v'):
+            return item
+
+    return 'n/a'
+
+
+def is_kano_public_release():
+    '''
+    returns True if this Kano system is a public release version
+    '''
+    return 'release' in get_kano_version_stamp().split('-')
+
+
+def is_kano_internal_development():
+    '''
+    returns True if this Kano system is an internal development version
+    '''
+    return not is_kano_public_release()


### PR DESCRIPTION
 * Allow to peek at version information chunks from the stamp file
 * Option to change the default stamp file for offline testing

@Ealdwulf @radujipa couldn't find them implemented elsewhere, think it's a good place here.

To aid on this PR: https://github.com/KanoComputing/os-dashboard/pull/249
