### PR TITLE
Allow kano-feedback-cli as root

### DIFF
--- a/bin/kano-logs
+++ b/bin/kano-logs
@@ -36,16 +36,9 @@ import pyinotify
 # Used for looking at logs off the pi. See -d option
 force_log_dirs = None
 
-def get_logfiles(app=None):
-    log_dirs = [logging.SYSTEM_LOGS_DIR]
-    if os.getuid() != 0:
-        log_dirs.append(logging.USER_LOGS_DIR)
-    else:
-        for f in os.listdir('/home'):
-            user_log_dir = '/home/{}/.kano-logs'.format(f)
-            if os.path.isdir(user_log_dir):
-                log_dirs.append(user_log_dir)
 
+def get_logfiles(app=None):
+    log_dirs = logging._get_log_dirs()
     if force_log_dirs is not None:
         log_dirs = force_log_dirs
 

--- a/kano/_logging.py
+++ b/kano/_logging.py
@@ -286,9 +286,21 @@ def _set_conf_var(var, value):
         f.write(yaml.dump(conf, default_flow_style=False))
 
 
+def _get_log_dirs():
+    log_dirs = [SYSTEM_LOGS_DIR]
+    if os.getuid() != 0:
+        log_dirs.append(USER_LOGS_DIR)
+    else:
+        for f in os.listdir('/home'):
+            user_log_dir = '/home/{}/.kano-logs'.format(f)
+            if os.path.isdir(user_log_dir):
+                log_dirs.append(user_log_dir)
+    return log_dirs
+
+
 def read_logs(app=None):
     data = {}
-    for d in [USER_LOGS_DIR, SYSTEM_LOGS_DIR]:
+    for d in _get_log_dirs():
         if os.path.isdir(d):
             for log in os.listdir(d):
                 if app is None or re.match("^{}\.log".format(app), log):


### PR DESCRIPTION
This PR changes read_logs() to iterate over all home directories if running as root.
There is already functionalilty in kano-logs to do this, so just refactor to allow that to be used.
For https://trello.com/c/NOQTpIYV
@skarbat @radujipa 