### PR TITLE
Prevent GUI thread from being blocked by UDHCPC hook processes

### DIFF
--- a/udhcpc/kano.script
+++ b/udhcpc/kano.script
@@ -32,12 +32,14 @@ function call_hook {
 
     # Collect and report RPi CPU ID
     if [ -x $network_hook ]; then
+        # TODO: investigate whether the process below would also need to pipe
+        # stdout and stderr to /dev/null if it uses run_cmd
         $network_hook $@ &
     fi
 
     # Download updates in the background
     if [ -x $updates_hook ]; then
-        $updates_hook $@ &
+        $updates_hook $@ > /dev/null 2>/dev/null &
     fi
 }
 


### PR DESCRIPTION
When connecting to WiFi, the kano.script is executed by the UDHCPC client.
In this script, we introduce various system hooks to the "internet connection
up" event. The latest one was kano-dashboard-sysupdates which launches the
Updater using the run_cmd command. Even though sysupdates is launched in the
background, processes spawned via run_cmd will block due to inheriting fds.

This fix says that the sysupdates should be run in the background and also
discard the standard output and error, on which it would block due to the
processes launched through run_cmd (since it uses Popen with piping
stdout and stderr).

@Ealdwulf @skarbat @tombettany 