### PR TITLE
Kano-Volume: Emit DBus signal when changing the volume

### DIFF
--- a/bin/kano-volume
+++ b/bin/kano-volume
@@ -30,12 +30,16 @@ updown=$1
 case $updown in
     "up")
         amixer set Master 1+ > /dev/null 2>&1
+        dbus-send --session --type=signal --dest=me.kano.audio /me/kano/audio me.kano.audio.volume.changed
+
         if [ "$omx_running" -eq 0 ]; then
             dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:18 >/dev/null
         fi
         ;;
     "down")
         amixer set Master 1- > /dev/null 2>&1
+        dbus-send --session --type=signal --dest=me.kano.audio /me/kano/audio me.kano.audio.volume.changed
+
         if [ "$omx_running" -eq 0 ]; then
             dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:17 >/dev/null
         fi


### PR DESCRIPTION
https://trello.com/c/PFHdtmzw/297-using-keyboard-shortcuts-for-controlling-volume-not-working-in-dashboard
Allow applications to discover a change in volume by emitting a DBus
signal to inform them that the value has changed.

cc @Ealdwulf @radujipa 