### PR TITLE
Parson: Fix i18n case where decimal separator is ','

### DIFF
--- a/libs/parson/lib/parson.c
+++ b/libs/parson/lib/parson.c
@@ -692,6 +692,13 @@ static JSON_Value * parse_boolean_value(const char **string) {
 static JSON_Value * parse_number_value(const char **string) {
     char *end;
     double number = strtod(*string, &end);
+
+    // Localised numbers can use `,` as a decimal separator and can end with ','
+    if (end
+            && strncmp(end, &entry_separator, 1) != 0
+            && strncmp(end - 1, &entry_separator, 1) == 0)
+        end--;
+
     JSON_Value *output_value;
     if (is_decimal(*string, end - *string)) {
         *string = end;

--- a/libs/parson/lib/parson.h
+++ b/libs/parson/lib/parson.h
@@ -215,6 +215,8 @@ const char  *   json_string (const JSON_Value *value);
 double          json_number (const JSON_Value *value);
 int             json_boolean(const JSON_Value *value);
     
+const char entry_separator = ',';
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
trello.com/c/blt0FDXx/392-updater-status-file-is-incorrectly-parsed-in-spanish-due-to-the-decimal-separator
If LC_NUMERIC is set to a locale which uses `,` as the decimal separator
for numbers then the `strtod()` function will interpret `,`s following
integers as part of the number. This causes problems when integers are
in a JSON as there will be a `,` following the number to correctly
adhere to JSON syntax but this will be interpreted as part of the number
which causes there to be no `,` separator between keys.

For example, in

{
    "key_1": 10,
    "key_2": 20
}

`key_1` would parse `10,` as 10.0 and absorb the trailing `,`. Allow for
this case by checking for trailing `,`.

@Ealdwulf to review.