### PR TITLE
Fix logging of exception objects

### DIFF
--- a/kano/_logging.py
+++ b/kano/_logging.py
@@ -187,7 +187,7 @@ class Logger:
             if 'exception' in kwargs:
                 import traceback
                 tbk = traceback.format_exc()
-                log['exception'] = kwargs['exception'].encode('utf8')
+                log['exception'] = unicode(kwargs['exception']).encode('utf8')
                 log['traceback'] = tbk
 
             for line in lines:


### PR DESCRIPTION
This PR fixes logging of exceptions. These are objects and must be converted to strings before 
encoding as utf-8.
@radujipa @tombettany 