### PR TITLE
Fixed issue with Make Snake launching windowed from Desktop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-toolset (3.15.0-0) unstable; urgency=low
+
+  * Fixed issue with Make Snake launching windowed from Desktop
+
+ -- Team Kano <dev@kano.me>  Tue, 19 Dec 2017 11:09:00 +0100
+
 kano-toolset (3.14.0-0) unstable; urgency=low
 
   * Moved kano content and tracking sync to network hooks from kano-ui-autostart

--- a/share/kano-launcher/conf/make-snake
+++ b/share/kano-launcher/conf/make-snake
@@ -1,2 +1,2 @@
 match_only_preset
-extra_cmd: kano-window-tool -t "Make Snake" -dyes -m -f
+extra_cmd: kano-window-tool -t "Make Snake" -dyes -f


### PR DESCRIPTION
For some reason the issue here came from kano-launcher when it
attempts to maximise the app. Make Snake already maximises itself
when it launches, but seems to be resized by the launcher afterwards
in Desktop mode.